### PR TITLE
Feature/add training planning

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirebasePlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirebasePlanRepository.kt
@@ -36,6 +36,14 @@ class FirebasePlanRepository: PlanRepository {
         }
     }
 
+    override suspend fun getCustomWorkout(userId: String, planId: String, workoutIdx: Int): WorkoutPlan {
+        return withContext(context) {
+            val plan = userPlanRef(userId).document(planId).get().data<Plan>()
+            val workout = plan.workouts.find { it.idx == workoutIdx }
+            return@withContext workout!! // TODO error checking
+        }
+    }
+
     override suspend fun saveCustomWorkout(userId: String, workoutPlan: WorkoutPlan) {
         withContext(context) {
             val id = userWorkoutPlanRef(userId).document.id

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirebasePlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirebasePlanRepository.kt
@@ -17,8 +17,16 @@ class FirebasePlanRepository: PlanRepository {
     private fun userWorkoutPlanRef(userId: String) = firestore.collection("USERS").document(userId).collection("WORKOUT_PLANS")
     private val context = Dispatchers.IO
 
-    override suspend fun getPredefinedPlans() {
-        TODO("Not yet implemented")
+    override fun getPredefinedPlans(): Flow<List<Plan>> {
+        return planRef.snapshots.map { snapshot ->
+            snapshot.documents.map { it.data<Plan>() }
+        }
+    }
+
+    override fun getCustomPlans(userId: String): Flow<List<Plan>> {
+        return userPlanRef(userId).snapshots.map { snapshot ->
+            snapshot.documents.map { it.data<Plan>() }
+        }
     }
 
     override suspend fun saveCustomPlan(userId: String, plan: Plan) {

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirebasePlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirebasePlanRepository.kt
@@ -1,0 +1,34 @@
+package io.github.jakubherr.gitfit.data.repository
+
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.firestore.firestore
+import io.github.jakubherr.gitfit.domain.PlanRepository
+import io.github.jakubherr.gitfit.domain.model.Plan
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class FirebasePlanRepository: PlanRepository {
+    private val firestore = Firebase.firestore
+    private val planRef = firestore.collection("PLANS")
+    private fun userPlanRef(userId: String) = firestore.collection("USERS").document(userId).collection("PLANS")
+    private val context = Dispatchers.IO
+
+    override suspend fun getPredefinedPlans() {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun saveCustomPlan(userId: String, plan: Plan) {
+        withContext(context) {
+            val id = userPlanRef(userId).document.id
+            userPlanRef(userId).document(id).set(plan.copy(id = id))
+        }
+    }
+
+    override suspend fun deleteCustomPlan(userId: String, planId: String) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteCustomPlans(userId: String) {
+        TODO("Not yet implemented")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirebasePlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirebasePlanRepository.kt
@@ -4,13 +4,17 @@ import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.firestore.firestore
 import io.github.jakubherr.gitfit.domain.PlanRepository
 import io.github.jakubherr.gitfit.domain.model.Plan
+import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
 class FirebasePlanRepository: PlanRepository {
     private val firestore = Firebase.firestore
     private val planRef = firestore.collection("PLANS")
     private fun userPlanRef(userId: String) = firestore.collection("USERS").document(userId).collection("PLANS")
+    private fun userWorkoutPlanRef(userId: String) = firestore.collection("USERS").document(userId).collection("WORKOUT_PLANS")
     private val context = Dispatchers.IO
 
     override suspend fun getPredefinedPlans() {
@@ -21,6 +25,19 @@ class FirebasePlanRepository: PlanRepository {
         withContext(context) {
             val id = userPlanRef(userId).document.id
             userPlanRef(userId).document(id).set(plan.copy(id = id))
+        }
+    }
+
+    override suspend fun saveCustomWorkout(userId: String, workoutPlan: WorkoutPlan) {
+        withContext(context) {
+            val id = userWorkoutPlanRef(userId).document.id
+            userWorkoutPlanRef(userId).document(id).set(workoutPlan.copy())
+        }
+    }
+
+    override fun getCustomWorkouts(userId: String): Flow<List<WorkoutPlan>> {
+        return userWorkoutPlanRef(userId).snapshots.map { snapshot ->
+            snapshot.documents.map { it.data<WorkoutPlan>() }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirestoreExerciseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirestoreExerciseRepository.kt
@@ -5,15 +5,16 @@ import dev.gitlive.firebase.firestore.firestore
 import io.github.jakubherr.gitfit.domain.ExerciseRepository
 import io.github.jakubherr.gitfit.domain.model.Exercise
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.withContext
 
 class FirestoreExerciseRepository : ExerciseRepository {
     private val exerciseRef = Firebase.firestore.collection("EXERCISES")
+    private fun userExerciseRef(userId: String) = Firebase.firestore.collection("USERS").document(userId).collection("EXERCISES")
     private val context = Dispatchers.IO
 
-    // TODO separate into read-only shared exercises that will be cached indefinitely and custom user exercises
-    override fun getAllExercises() =
+    override fun getDefaultExercises() =
         flow {
             exerciseRef.snapshots.collect { snapshot ->
                 val exercises =
@@ -24,13 +25,27 @@ class FirestoreExerciseRepository : ExerciseRepository {
             }
         }
 
-    override suspend fun createExercise(exercise: Exercise) {
+    override suspend fun addDefaultExercise(exercise: Exercise) {
         withContext(context) {
             val id = exerciseRef.document.id
             exerciseRef.document(id).set(exercise.copy(id = id))
         }
     }
 
+    override fun getCustomExercises(userId: String): Flow<List<Exercise>> = flow {
+        userExerciseRef(userId).snapshots.collect { snapshot ->
+            val exercises = snapshot.documents.map { it.data<Exercise>() }
+            emit(exercises)
+        }
+    }
+
+    override suspend fun addCustomExercise(userId: String, exercise: Exercise) {
+        withContext(context) {
+            val id = userExerciseRef(userId).document.id
+            userExerciseRef(userId).document(id).set(exercise.copy(id = id))
+        }
+    }
+
     // consider what to do with all existing workouts that already use this exercise
-    // fun deleteExercise()
+    // fun deleteCustomExercise()
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirestoreWorkoutRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirestoreWorkoutRepository.kt
@@ -1,7 +1,6 @@
 package io.github.jakubherr.gitfit.data.repository
 
 import dev.gitlive.firebase.Firebase
-import dev.gitlive.firebase.firestore.FieldValue
 import dev.gitlive.firebase.firestore.firestore
 import io.github.jakubherr.gitfit.domain.AuthRepository
 import io.github.jakubherr.gitfit.domain.PlanRepository
@@ -11,38 +10,13 @@ import io.github.jakubherr.gitfit.domain.model.Exercise
 import io.github.jakubherr.gitfit.domain.model.Series
 import io.github.jakubherr.gitfit.domain.model.Workout
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
-import kotlinx.serialization.Serializable
-
-@Serializable
-private data class WorkoutDTO(
-    val id: String,
-    val userId: String,
-    val date: LocalDate,
-    val completed: Boolean = false,
-    val inProgress: Boolean = false,
-) {
-    fun toWorkout(blocks: List<Block> = emptyList()) =
-        Workout(
-            id = id,
-            userId = userId,
-            blocks = blocks,
-            date = date,
-            completed = completed,
-            inProgress = inProgress,
-        )
-}
 
 // TODO handle uncached data, null value when something is not found
 //  maybe store unfinished workouts locally and only upload them on completion
@@ -52,204 +26,221 @@ class FirestoreWorkoutRepository(
 ) : WorkoutRepository {
     private val firestore = Firebase.firestore
     private val dispatcher = Dispatchers.IO
-    private val workoutRef = firestore.collection("WORKOUTS")
+    private fun workoutRef(userId: String) = firestore.collection("USERS").document(userId).collection("WORKOUTS")
 
-    private fun blockRef(
-        workoutId: String,
-        blockId: String,
-    ) = workoutRef.document(workoutId).collection("BLOCKS").document(blockId)
+    override fun observeCurrentWorkoutOrNull(): Flow<Workout?> {
+        val userId = authRepository.currentUser.id.ifBlank { return emptyFlow() }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    override fun observeCurrentWorkoutOrNull() =
-        observeCurrentWorkout()
-            .flatMapLatest { workoutDto ->
-                workoutDto?.let {
-                    observeBlocks(workoutDto.id).map { blocks ->
-                        it.toWorkout(blocks)
-                    }
-                } ?: flowOf(null)
+        return workoutRef(userId)
+            .where {
+                ("completed" equalTo false) and
+                        ("inProgress" equalTo true)
             }
+            .snapshots.map { workoutSnapshot ->
+                workoutSnapshot.documents.firstOrNull()?.data<Workout>()
+            }
+    }
 
     override suspend fun startNewWorkout() {
         withContext(dispatcher) {
             val userId = authRepository.currentUser.id.ifBlank { return@withContext } // TODO notify of failure
+            val id = workoutRef(userId).document.id
 
-            val id = workoutRef.document.id
             println("DBG: starting new workout with id $id")
-            val workout =
-                WorkoutDTO(
-                    id = id,
-                    userId = userId,
-                    date = Clock.System.todayIn(TimeZone.currentSystemDefault()),
-                    completed = false,
-                    inProgress = true,
-                )
+            val workout = Workout(
+                id = id,
+                userId = userId,
+                date = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+                blocks = emptyList(),
+                completed = false,
+                inProgress = true,
+            )
 
-            workoutRef.document(id).set(workout)
+            workoutRef(userId).document(id).set(workout)
         }
     }
 
     override suspend fun startWorkoutFromPlan(planId: String, workoutIdx: Int) {
-        val uid = authRepository.currentUser.id.ifBlank { return }
+        val userId = authRepository.currentUser.id.ifBlank { return }
         println("DBG: starting planned workout with index $workoutIdx from plan $planId")
 
-        val plan = planRepository.getCustomWorkout(uid, planId, workoutIdx)
+        val plan = planRepository.getCustomWorkout(userId, planId, workoutIdx)
 
         withContext(dispatcher) {
-            val id = workoutRef.document.id
+            val id = workoutRef(userId).document.id
 
             val workout = Workout(
                 id = id,
-                userId = uid,
+                userId = userId,
                 blocks = plan.blocks,
                 completed = false,
                 inProgress = true,
             )
 
-            workoutRef.document(id).set(workout)
+            workoutRef(userId).document(id).set(workout)
         }
     }
 
     override suspend fun completeWorkout(workoutId: String) {
+        val userId = authRepository.currentUser.id.ifBlank { return }
         withContext(dispatcher) {
-            workoutRef.document(workoutId).update("completed" to true, "inProgress" to false)
+            workoutRef(userId).document(workoutId).update("completed" to true, "inProgress" to false)
         }
     }
 
     override suspend fun deleteWorkout(workoutId: String) {
-        withContext(dispatcher) {
-            firestore.runTransaction {
-                val blocks = workoutRef.document(workoutId).collection("BLOCKS").get().documents
-                blocks.forEach {
-                    launch {
-                        workoutRef.document(workoutId).collection("BLOCKS").document(it.id).delete()
-                    }
-                }
-                workoutRef.document(workoutId).delete()
-            }
-        }
+        val userId = authRepository.currentUser.id.ifBlank { return }
+        withContext(dispatcher) { workoutRef(userId).document(workoutId).delete() }
     }
 
     override suspend fun addBlock(
         workoutId: String,
         exerciseId: String,
     ) {
+        val userId = authRepository.currentUser.id.ifBlank { return }
+
         withContext(dispatcher) {
+            // TODO this implementation assumes the workout only uses predefined exercises, FIX
+            //  maybe just send workout and exercise as objects?
             val exercise = firestore.collection("EXERCISES").document(exerciseId).get().data<Exercise>()
 
-            val id = workoutRef.document(workoutId).collection("BLOCKS").document.id
-            val block =
-                Block(
-                    id,
-                    0, // TODO solve indexing on unplanned workouts!
-                    exercise,
-                    emptyList(),
-                    null,
-                )
+            val workout = getWorkout(userId, workoutId)
 
-            blockRef(workoutId, id).set(block)
+            val block = Block(
+                workout.blocks.size,
+                exercise,
+                emptyList(),
+                null,
+            )
+
+            val newWorkout = workout.copy(blocks = workout.blocks + block)
+
+            workoutRef(userId).document(workoutId).set(newWorkout)
         }
     }
 
     override suspend fun removeBlock(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
     ) {
+        val userId = authRepository.currentUser.id.ifBlank { return }
+
         withContext(dispatcher) {
-            blockRef(workoutId, blockId).delete()
+            val workout = getWorkout(userId, workoutId)
+            val newBlocks = workout.blocks.toMutableList()
+            newBlocks.removeAt(blockIdx)
+            workoutRef(userId).document(workoutId).set(workout.copy(blocks = newBlocks))
         }
     }
 
     override suspend fun setBlockTimer(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         seconds: Long?,
     ) {
+        val userId = authRepository.currentUser.id.ifBlank { return }
+
         withContext(dispatcher) {
-            blockRef(workoutId, blockId).update("restTimeSeconds" to seconds)
+            val workout = getWorkout(userId, workoutId)
+            val newBlock = workout.blocks[blockIdx].copy(restTimeSeconds = seconds)
+            val newWorkout = workout.mutateBlock(newBlock)
+            workoutRef(userId).document(workoutId).set(newWorkout)
         }
     }
 
     override suspend fun addSeries(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         set: Series,
     ) {
+        val userId = authRepository.currentUser.id.ifBlank { return }
+
         withContext(dispatcher) {
-            blockRef(workoutId, blockId).update("series" to FieldValue.arrayUnion(set))
+            val workout = getWorkout(userId, workoutId)
+
+            val oldBlock = workout.blocks[blockIdx]
+            val emptySeries = Series(oldBlock.series.size, null, null, false)
+            val newWorkout = workout.mutateBlock(oldBlock.copy(series = oldBlock.series + emptySeries))
+
+            workoutRef(userId).document(workoutId).set(newWorkout)
         }
     }
 
     override suspend fun modifySeries(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         set: Series,
     ) {
-        val field = blockRef(workoutId, blockId).get().data<Block>().series
-        val newField = field.map { if (it.id == set.id) set else it }
+        val userId = authRepository.currentUser.id.ifBlank { return }
 
-        blockRef(workoutId, blockId).update("series" to newField)
+        withContext(dispatcher) {
+            val workout = getWorkout(userId, workoutId)
+            val newBlock = workout.blocks[blockIdx].mutateSeries(set)
+            val newWorkout = workout.mutateBlock(newBlock)
+            workoutRef(userId).document(workoutId).set(newWorkout)
+        }
+    }
+
+    private suspend fun getWorkout(
+        userId: String,
+        workoutId: String
+    ) = workoutRef(userId).document(workoutId).get().data<Workout>()
+
+    private fun Workout.mutateBlock(block: Block): Workout {
+        val newBlocks = blocks.toMutableList()
+        newBlocks[block.idx] = block
+        return copy(blocks = newBlocks)
+    }
+
+    private fun Block.mutateSeries(set: Series) : Block {
+        val newSeries = series.toMutableList()
+        newSeries[set.idx] = set
+        return copy(series = newSeries)
     }
 
     override suspend fun removeSeries(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         set: Series,
     ) {
+        val userId = authRepository.currentUser.id.ifBlank { return }
+
         withContext(dispatcher) {
-            blockRef(workoutId, blockId).update("series" to FieldValue.arrayRemove(set))
+            val workout = getWorkout(userId, workoutId)
+
+            val oldBlock = workout.blocks[blockIdx]
+            val newBlock = oldBlock.copy(series = oldBlock.series - set)
+            val newWorkout = workout.mutateBlock(newBlock)
+
+            workoutRef(userId).document(workoutId).set(newWorkout)
         }
     }
 
     override fun getCompletedWorkouts(): Flow<List<Workout>> {
-        val uid = authRepository.currentUser.id.ifBlank { return emptyFlow() }
+        val userId = authRepository.currentUser.id.ifBlank { return emptyFlow() }
 
-        return workoutRef
+        return workoutRef(userId)
             .where {
-                ("userId" equalTo uid) and
-                    ("completed" equalTo true) and
-                    ("inProgress" equalTo false)
+                        ("completed" equalTo true) and
+                        ("inProgress" equalTo false)
             }
             .snapshots
             .map { snapshot ->
-                snapshot.documents.map { it.data<WorkoutDTO>().toWorkout() }
+                snapshot.documents.map { it.data<Workout>() }
             }
     }
 
     override fun getPlannedWorkouts(): Flow<List<Workout>> {
-        val uid = authRepository.currentUser.id.ifBlank { return emptyFlow() }
+        val userId = authRepository.currentUser.id.ifBlank { return emptyFlow() }
 
-        return workoutRef
+        return workoutRef(userId)
             .where {
-                ("userId" equalTo uid) and
                     ("completed" equalTo false) and
                     ("inProgress" equalTo false)
             }
             .snapshots
             .map { snapshot ->
-                snapshot.documents.map { it.data<WorkoutDTO>().toWorkout() }
-            }
-    }
-
-    private fun observeBlocks(workoutId: String) =
-        workoutRef
-            .document(workoutId)
-            .collection("BLOCKS")
-            .snapshots.map { querySnapshot ->
-                querySnapshot.documents.map { it.data<Block>() }
-            }
-
-    private fun observeCurrentWorkout(): Flow<WorkoutDTO?> {
-        val uid = authRepository.currentUser.id.ifBlank { return emptyFlow() }
-
-        return workoutRef
-            .where {
-                ("userId" equalTo uid) and
-                    ("completed" equalTo false) and
-                    ("inProgress" equalTo true)
-            }
-            .snapshots.map { workoutSnapshot ->
-                workoutSnapshot.documents.firstOrNull()?.data<WorkoutDTO>()
+                snapshot.documents.map { it.data<Workout>() }
             }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirestoreWorkoutRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/data/repository/FirestoreWorkoutRepository.kt
@@ -124,6 +124,7 @@ class FirestoreWorkoutRepository : WorkoutRepository {
             val block =
                 Block(
                     id,
+                    0, // TODO solve indexing on unplanned workouts!
                     exercise,
                     emptyList(),
                     null,

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/di/KoinModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/di/KoinModule.kt
@@ -1,12 +1,14 @@
 package io.github.jakubherr.gitfit.di
 
 import io.github.jakubherr.gitfit.data.repository.FirebaseAuthRepository
+import io.github.jakubherr.gitfit.data.repository.FirebasePlanRepository
 import io.github.jakubherr.gitfit.data.repository.FirestoreExerciseRepository
 import io.github.jakubherr.gitfit.data.repository.FirestoreMeasurementRepository
 import io.github.jakubherr.gitfit.data.repository.FirestoreWorkoutRepository
 import io.github.jakubherr.gitfit.domain.AuthRepository
 import io.github.jakubherr.gitfit.domain.ExerciseRepository
 import io.github.jakubherr.gitfit.domain.MeasurementRepository
+import io.github.jakubherr.gitfit.domain.PlanRepository
 import io.github.jakubherr.gitfit.domain.WorkoutRepository
 import io.github.jakubherr.gitfit.presentation.auth.AuthViewModel
 import io.github.jakubherr.gitfit.presentation.exercise.ExerciseViewModel
@@ -31,6 +33,7 @@ private val repositoryModule =
         singleOf(::FirestoreWorkoutRepository).bind<WorkoutRepository>()
         singleOf(::FirebaseAuthRepository).bind<AuthRepository>()
         singleOf(::FirestoreMeasurementRepository).bind<MeasurementRepository>()
+        singleOf(::FirebasePlanRepository).bind<PlanRepository>()
     }
 
 expect val platformModule: Module

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/di/KoinModule.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/di/KoinModule.kt
@@ -11,6 +11,7 @@ import io.github.jakubherr.gitfit.domain.WorkoutRepository
 import io.github.jakubherr.gitfit.presentation.auth.AuthViewModel
 import io.github.jakubherr.gitfit.presentation.exercise.ExerciseViewModel
 import io.github.jakubherr.gitfit.presentation.measurement.MeasurementViewModel
+import io.github.jakubherr.gitfit.presentation.planning.PlanningViewModel
 import io.github.jakubherr.gitfit.presentation.workout.WorkoutViewModel
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
@@ -40,6 +41,7 @@ private val viewmodelModule =
         viewModelOf(::WorkoutViewModel)
         viewModelOf(::ExerciseViewModel)
         viewModelOf(::MeasurementViewModel)
+        viewModelOf(::PlanningViewModel)
     }
 
 private val sharedModules = listOf(viewmodelModule, repositoryModule, apiModule)

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/ExerciseRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/ExerciseRepository.kt
@@ -4,7 +4,12 @@ import io.github.jakubherr.gitfit.domain.model.Exercise
 import kotlinx.coroutines.flow.Flow
 
 interface ExerciseRepository {
-    fun getAllExercises(): Flow<List<Exercise>> // TODO use pagination to limit reads
+    fun getDefaultExercises(): Flow<List<Exercise>> // TODO use pagination to limit reads
 
-    suspend fun createExercise(exercise: Exercise) // TODO use results?
+    fun getCustomExercises(userId: String): Flow<List<Exercise>>
+
+    suspend fun addCustomExercise(userId: String, exercise: Exercise) // TODO use results?
+
+    // TODO use to fill Firebase with predefined exercises and remove
+    suspend fun addDefaultExercise(exercise: Exercise)
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/MeasurementRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/MeasurementRepository.kt
@@ -5,9 +5,9 @@ import io.github.jakubherr.gitfit.domain.model.Measurement
 interface MeasurementRepository {
     suspend fun getAllMeasurements(userId: String): List<Measurement>
 
-    suspend fun addMeasurement(measurement: Measurement)
+    suspend fun addMeasurement(userId: String, measurement: Measurement)
 
-    suspend fun deleteMeasurement(measurementId: String)
+    suspend fun deleteMeasurement(userId: String, measurementId: String)
 
     suspend fun deleteAll(userId: String)
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
@@ -11,11 +11,9 @@ interface PlanRepository {
 
     suspend fun saveCustomPlan(userId: String, plan: Plan)
 
-    suspend fun getCustomWorkout(userId: String, planId: String, workoutIdx: Int): WorkoutPlan
-
-    // TODO edit existing plan
-
     suspend fun deleteCustomPlan(userId: String, planId: String)
 
     suspend fun deleteCustomPlans(userId: String)
+
+    suspend fun getCustomWorkout(userId: String, planId: String, workoutIdx: Int): WorkoutPlan
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
@@ -13,11 +13,8 @@ interface PlanRepository {
 
     suspend fun getCustomWorkout(userId: String, planId: String, workoutIdx: Int): WorkoutPlan
 
-    suspend fun saveCustomWorkout(userId: String, workoutPlan: WorkoutPlan)
+    // TODO edit existing plan
 
-    fun getCustomWorkouts(userId: String): Flow<List<WorkoutPlan>>
-
-    // modify existing plan?
     suspend fun deleteCustomPlan(userId: String, planId: String)
 
     suspend fun deleteCustomPlans(userId: String)

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
@@ -5,7 +5,9 @@ import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
 import kotlinx.coroutines.flow.Flow
 
 interface PlanRepository {
-    suspend fun getPredefinedPlans()
+    fun getPredefinedPlans(): Flow<List<Plan>>
+
+    fun getCustomPlans(userId: String): Flow<List<Plan>>
 
     suspend fun saveCustomPlan(userId: String, plan: Plan)
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
@@ -5,10 +5,10 @@ import io.github.jakubherr.gitfit.domain.model.Plan
 interface PlanRepository {
     suspend fun getPredefinedPlans()
 
-    suspend fun createCustomPlan(plan: Plan)
+    suspend fun saveCustomPlan(userId: String, plan: Plan)
 
     // modify existing plan?
-    suspend fun deleteCustomPlan(planId: String)
+    suspend fun deleteCustomPlan(userId: String, planId: String)
 
-    suspend fun deleteAllCustomPlans(userId: String)
+    suspend fun deleteCustomPlans(userId: String)
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
@@ -11,6 +11,8 @@ interface PlanRepository {
 
     suspend fun saveCustomPlan(userId: String, plan: Plan)
 
+    suspend fun getCustomWorkout(userId: String, planId: String, workoutIdx: Int): WorkoutPlan
+
     suspend fun saveCustomWorkout(userId: String, workoutPlan: WorkoutPlan)
 
     fun getCustomWorkouts(userId: String): Flow<List<WorkoutPlan>>

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/PlanRepository.kt
@@ -1,11 +1,17 @@
 package io.github.jakubherr.gitfit.domain
 
 import io.github.jakubherr.gitfit.domain.model.Plan
+import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
+import kotlinx.coroutines.flow.Flow
 
 interface PlanRepository {
     suspend fun getPredefinedPlans()
 
     suspend fun saveCustomPlan(userId: String, plan: Plan)
+
+    suspend fun saveCustomWorkout(userId: String, workoutPlan: WorkoutPlan)
+
+    fun getCustomWorkouts(userId: String): Flow<List<WorkoutPlan>>
 
     // modify existing plan?
     suspend fun deleteCustomPlan(userId: String, planId: String)

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/Util.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/Util.kt
@@ -1,7 +1,7 @@
 package io.github.jakubherr.gitfit.domain
 
+// note: these functions assume 0 is a valid input (user failed exercise, user used no weight)
 fun String.isPositiveLong() = toLongOrNull().let { it != null && it >= 0 }
-
 fun String.isPositiveDouble() = toDoubleOrNull().let { it != null && it >= 0.0 }
 
 // note: this function is for UI purposes only and is double-checked by backend

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/WorkoutRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/WorkoutRepository.kt
@@ -4,7 +4,6 @@ import io.github.jakubherr.gitfit.domain.model.Series
 import io.github.jakubherr.gitfit.domain.model.Workout
 import kotlinx.coroutines.flow.Flow
 
-// TODO pagination
 interface WorkoutRepository {
     fun observeCurrentWorkoutOrNull(): Flow<Workout?>
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/WorkoutRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/WorkoutRepository.kt
@@ -10,7 +10,7 @@ interface WorkoutRepository {
 
     suspend fun startNewWorkout()
 
-    suspend fun startPlannedWorkout(workoutId: String)
+    suspend fun startWorkoutFromPlan(planId: String, workoutIdx: Int)
 
     suspend fun completeWorkout(workoutId: String)
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/WorkoutRepository.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/WorkoutRepository.kt
@@ -23,30 +23,30 @@ interface WorkoutRepository {
 
     suspend fun removeBlock(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
     )
 
     suspend fun setBlockTimer(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         seconds: Long?,
     )
 
     suspend fun addSeries(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         set: Series,
     )
 
     suspend fun modifySeries(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         set: Series,
     )
 
     suspend fun removeSeries(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         set: Series,
     )
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Exercise.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Exercise.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Exercise(
     val id: String,
-    val userId: String?,
     val name: String,
     val description: String?,
     val primaryMuscle: List<MuscleGroup> = emptyList(),
@@ -26,7 +25,6 @@ enum class MuscleGroup {
 val mockExercise =
     Exercise(
         "mock",
-        null,
         "Bench press",
         "",
         listOf(MuscleGroup.CHEST),

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Measurement.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Measurement.kt
@@ -8,8 +8,6 @@ import kotlinx.serialization.Serializable
 // if a measurement already exists for the current day, it should overwrite the old instead of adding a new one
 @Serializable
 data class Measurement(
-    val id: String,
-    val userId: String,
     val date: LocalDate,
     // TODO units
     val neck: Double?,

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Plan.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Plan.kt
@@ -1,7 +1,10 @@
 package io.github.jakubherr.gitfit.domain.model
 
+import kotlinx.serialization.Serializable
+
 // a plan could be either predefined or custom made by the user
 // custom plans are private
+@Serializable
 data class Plan(
     val id: String,
     val userId: String?,
@@ -9,7 +12,7 @@ data class Plan(
     val description: String,
     val workouts: List<WorkoutPlan> = emptyList()
     // difficulty
-    // required equipment
+    // required equipment (maybe calculation based on present exercises would be nice)
     // category: upper/lower, PPL, full body
     // progression - increase reps per set, increase weight
 )

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Plan.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Plan.kt
@@ -7,6 +7,7 @@ data class Plan(
     val userId: String?,
     val name: String,
     val description: String,
+    val workouts: List<WorkoutPlan> = emptyList()
     // difficulty
     // required equipment
     // category: upper/lower, PPL, full body

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Plan.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Plan.kt
@@ -15,4 +15,8 @@ data class Plan(
     // required equipment (maybe calculation based on present exercises would be nice)
     // category: upper/lower, PPL, full body
     // progression - increase reps per set, increase weight
-)
+) {
+    companion object {
+        val Empty = Plan("","","","")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/User.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/User.kt
@@ -1,7 +1,7 @@
 package io.github.jakubherr.gitfit.domain.model
 
 data class User(
-    val userId: String,
+    val id: String,
     val email: String,
     val loggedIn: Boolean,
     val emailVerified: Boolean,

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
@@ -55,8 +55,7 @@ data class Block(
 data class Series(
     val idx: Int,
     val repetitions: Long?,
-    // TODO weight should be double!!
-    val weight: Long?,
+    val weight: Double?,
     val completed: Boolean,
 )
 
@@ -64,7 +63,7 @@ val mockSeries =
     Series(
         0,
         repetitions = 3,
-        weight = 40,
+        weight = 40.0,
         completed = false,
     )
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
@@ -16,11 +16,30 @@ data class Workout(
     val inProgress: Boolean = false,
 )
 
+@Serializable
 data class WorkoutPlan(
     val name: String = "",
     val idx: Int,
     val blocks: List<Block>,
 )
+
+data class ProgressionSettings(
+    val incrementWeightByKg: Double,
+    val incrementReps: Int,
+    val type: ProgressionType,
+    val trigger: ProgressionTrigger,
+    val threshold: Int,
+)
+
+enum class ProgressionType {
+    INCREASE_REPS,
+    INCREASE_WEIGHT,
+}
+
+enum class ProgressionTrigger {
+    MINIMUM_REPS_EVERY_SET,
+    EVERY_WORKOUT,
+}
 
 @Serializable
 data class Block(

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
@@ -43,7 +43,6 @@ enum class ProgressionTrigger {
 
 @Serializable
 data class Block(
-    // TODO consider using index since it is inside a subcollection anyway
     val id: String,
     val idx: Int,
     val exercise: Exercise,
@@ -57,7 +56,7 @@ data class Series(
     val id: String,
     val idx: Int,
     val repetitions: Long?,
-    // TODO weight should be double
+    // TODO weight should be double!!
     val weight: Long?,
     val completed: Boolean,
 )

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
@@ -36,6 +36,7 @@ data class Block(
 @Serializable
 data class Series(
     val id: String,
+    val idx: Int,
     val repetitions: Long?,
     // TODO weight should be double
     val weight: Long?,
@@ -45,6 +46,7 @@ data class Series(
 val mockSeries =
     Series(
         id = "mock",
+        0,
         repetitions = 3,
         weight = 40,
         completed = false,

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
@@ -9,19 +9,27 @@ import kotlinx.serialization.Serializable
 data class Workout(
     val id: String,
     val userId: String,
+    val name: String = "",
     val blocks: List<Block>,
     val date: LocalDate,
     val completed: Boolean = false,
     val inProgress: Boolean = false,
 )
 
+data class WorkoutPlan(
+    val name: String = "",
+    val idx: Int,
+    val blocks: List<Block>,
+)
+
 @Serializable
 data class Block(
     // TODO consider using index since it is inside a subcollection anyway
     val id: String,
+    val idx: Int,
     val exercise: Exercise,
     val series: List<Series> = emptyList(),
-    val restTimeSeconds: Long?,
+    val restTimeSeconds: Long? = null,
 )
 
 // this should be named Set but is named series because of name conflict with Set collection
@@ -45,6 +53,7 @@ val mockSeries =
 val mockBlock =
     Block(
         id = "mock",
+        idx = 0,
         exercise = mockExercise,
         series = listOf(mockSeries),
         restTimeSeconds = 69,

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
@@ -44,7 +44,6 @@ enum class ProgressionTrigger {
 
 @Serializable
 data class Block(
-    val id: String,
     val idx: Int,
     val exercise: Exercise,
     val series: List<Series> = emptyList(),
@@ -54,7 +53,6 @@ data class Block(
 // this should be named Set but is named series because of name conflict with Set collection
 @Serializable
 data class Series(
-    val id: String,
     val idx: Int,
     val repetitions: Long?,
     // TODO weight should be double!!
@@ -64,7 +62,6 @@ data class Series(
 
 val mockSeries =
     Series(
-        id = "mock",
         0,
         repetitions = 3,
         weight = 40,
@@ -73,7 +70,6 @@ val mockSeries =
 
 val mockBlock =
     Block(
-        id = "mock",
         idx = 0,
         exercise = mockExercise,
         series = listOf(mockSeries),

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Workout.kt
@@ -6,12 +6,13 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.todayIn
 import kotlinx.serialization.Serializable
 
+@Serializable
 data class Workout(
     val id: String,
     val userId: String,
     val name: String = "",
     val blocks: List<Block>,
-    val date: LocalDate,
+    val date: LocalDate = Clock.System.todayIn(TimeZone.currentSystemDefault()),
     val completed: Boolean = false,
     val inProgress: Boolean = false,
 )

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitNavHost.kt
@@ -19,7 +19,8 @@ import io.github.jakubherr.gitfit.presentation.dashboard.DashboardAction
 import io.github.jakubherr.gitfit.presentation.dashboard.DashboardScreenRoot
 import io.github.jakubherr.gitfit.presentation.exercise.exerciseNavigation
 import io.github.jakubherr.gitfit.presentation.measurement.MeasurementScreenRoot
-import io.github.jakubherr.gitfit.presentation.planning.PlanningScreenRoot
+import io.github.jakubherr.gitfit.presentation.planning.PlanningViewModel
+import io.github.jakubherr.gitfit.presentation.planning.planningGraph
 import io.github.jakubherr.gitfit.presentation.settings.SettingsScreenRoot
 import io.github.jakubherr.gitfit.presentation.workout.WorkoutScreenRoot
 import org.koin.compose.viewmodel.koinViewModel
@@ -35,6 +36,8 @@ fun GitFitNavHost(
 
     val authViewModel: AuthViewModel = koinViewModel()
     val auth by authViewModel.state.collectAsStateWithLifecycle()
+
+    val planViewModel: PlanningViewModel = koinViewModel()
 
     LaunchedEffect(auth) { println("DBG: auth state is $auth") }
 
@@ -74,11 +77,8 @@ fun GitFitNavHost(
                 )
             }
 
-            exerciseNavigation(navController)
-
-            composable<PlanningRoute> {
-                PlanningScreenRoot()
-            }
+            exerciseNavigation(navController, planViewModel) // TODO: evaluate if this is a good idea
+            planningGraph(navController, planViewModel)
 
             composable<MeasurementRoute> {
                 MeasurementScreenRoot()
@@ -102,7 +102,7 @@ private fun NavHostController.navigateToTopLevelDestination(destination: TopLeve
             TopLevelDestination.DASHBOARD -> DashboardRoute
             TopLevelDestination.TRENDS -> TrendsRoute
             TopLevelDestination.MEASUREMENT -> MeasurementRoute
-            TopLevelDestination.PLAN -> PlanningRoute
+            TopLevelDestination.PLAN -> PlanOverviewRoute
             TopLevelDestination.PROFILE -> SettingsRoute
         }
     navigate(route) {

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitNavHost.kt
@@ -19,6 +19,7 @@ import io.github.jakubherr.gitfit.presentation.dashboard.DashboardAction
 import io.github.jakubherr.gitfit.presentation.dashboard.DashboardScreenRoot
 import io.github.jakubherr.gitfit.presentation.exercise.exerciseNavigation
 import io.github.jakubherr.gitfit.presentation.measurement.MeasurementScreenRoot
+import io.github.jakubherr.gitfit.presentation.planning.PlanningScreenRoot
 import io.github.jakubherr.gitfit.presentation.settings.SettingsScreenRoot
 import io.github.jakubherr.gitfit.presentation.workout.WorkoutScreenRoot
 import org.koin.compose.viewmodel.koinViewModel
@@ -76,7 +77,7 @@ fun GitFitNavHost(
             exerciseNavigation(navController)
 
             composable<PlanningRoute> {
-                // TODO
+                PlanningScreenRoot()
             }
 
             composable<MeasurementRoute> {

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitNavHost.kt
@@ -37,6 +37,7 @@ fun GitFitNavHost(
     val authViewModel: AuthViewModel = koinViewModel()
     val auth by authViewModel.state.collectAsStateWithLifecycle()
 
+    // this prevents data loss of in-memory plan
     val planViewModel: PlanningViewModel = koinViewModel()
 
     LaunchedEffect(auth) { println("DBG: auth state is $auth") }
@@ -77,7 +78,7 @@ fun GitFitNavHost(
                 )
             }
 
-            exerciseNavigation(navController, planViewModel) // TODO: evaluate if this is a good idea
+            exerciseNavigation(navController) // TODO: evaluate if this is a good idea
             planningGraph(navController, planViewModel)
 
             composable<MeasurementRoute> {

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitNavHost.kt
@@ -1,5 +1,6 @@
 package io.github.jakubherr.gitfit.presentation
 
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -42,9 +43,12 @@ fun GitFitNavHost(
 
     LaunchedEffect(auth) { println("DBG: auth state is $auth") }
 
+    val snackbarHostState = remember { SnackbarHostState() }
+
     GitFitScaffold(
         showDestinations = showNavigation,
         currentDestination = topLevelDestination,
+        snackbarHostState = snackbarHostState,
         onDestinationClicked = {
             navController.navigateToTopLevelDestination(it)
         },
@@ -78,8 +82,8 @@ fun GitFitNavHost(
                 )
             }
 
-            exerciseNavigation(navController) // TODO: evaluate if this is a good idea
-            planningGraph(navController, planViewModel)
+            exerciseNavigation(navController)
+            planningGraph(navController, planViewModel, snackbarHostState)
 
             composable<MeasurementRoute> {
                 MeasurementScreenRoot()

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitScaffold.kt
@@ -7,6 +7,9 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.SettingsAccessibility
 import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
@@ -43,6 +46,7 @@ fun GitFitScaffold(
     showDestinations: Boolean = true,
     currentDestination: TopLevelDestination?,
     onDestinationClicked: (TopLevelDestination) -> Unit = {},
+    snackbarHostState: SnackbarHostState = SnackbarHostState(),
     content: @Composable () -> Unit,
 ) {
     val layoutType =
@@ -73,9 +77,15 @@ fun GitFitScaffold(
             },
             layoutType = layoutType,
             modifier = modifier,
-            content = content,
+            content = {
+                Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
+                    content()
+                }
+            },
         )
     } else {
-        content()
+        Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
+            content()
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/GitFitScaffold.kt
@@ -33,7 +33,7 @@ enum class TopLevelDestination(
     DASHBOARD(Res.string.dashboard, Icons.Default.Home, DashboardRoute::class),
     TRENDS(Res.string.trends, Icons.Default.Timeline, TrendsRoute::class),
     MEASUREMENT(Res.string.measurement, Icons.Default.SettingsAccessibility, MeasurementRoute::class),
-    PLAN(Res.string.plan, Icons.Default.EditCalendar, PlanningRoute::class),
+    PLAN(Res.string.plan, Icons.Default.EditCalendar, PlanOverviewRoute::class),
     PROFILE(Res.string.profile, Icons.Default.AccountBox, SettingsRoute::class),
 }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/Routes.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/Routes.kt
@@ -30,6 +30,9 @@ object ExerciseListRoute
 class AddExerciseToWorkoutRoute(val workoutId: String)
 
 @Serializable
+class AddExerciseToPlanRoute(val workoutIdx: Int)
+
+@Serializable
 data class ExerciseDetailRoute(val id: String)
 
 @Serializable
@@ -39,7 +42,13 @@ object CreateExerciseRoute
 object MeasurementRoute
 
 @Serializable
-object PlanningRoute
+object PlanOverviewRoute
+
+@Serializable
+object PlanCreationRoute
+
+@Serializable
+class PlanningWorkoutRoute(val workoutIdx: Int)
 
 @Serializable
 object TrendsRoute

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/Routes.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/Routes.kt
@@ -1,5 +1,6 @@
 package io.github.jakubherr.gitfit.presentation
 
+import io.github.jakubherr.gitfit.domain.model.Plan
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -43,6 +44,9 @@ object MeasurementRoute
 
 @Serializable
 object PlanOverviewRoute
+
+@Serializable
+class PlanDetailRoute(val planId: String)
 
 @Serializable
 object PlanCreationRoute

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/auth/AuthViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/auth/AuthViewModel.kt
@@ -57,7 +57,7 @@ class AuthViewModel(
     }
 
     private fun signOut() {
-        println("DBG: signing out ${state.value.user.userId}...")
+        println("DBG: signing out ${state.value.user.id}...")
         launch { auth.signOut() }
     }
 
@@ -71,7 +71,7 @@ class AuthViewModel(
     }
 
     private fun deleteAccount(password: String) {
-        println("DBG: deleting user ${state.value.user.userId}")
+        println("DBG: deleting user ${state.value.user.id}")
         launch { auth.deleteUser(password) }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/dashboard/DashboardScreen.kt
@@ -44,7 +44,7 @@ fun DashboardScreenRoot(
     ) { action ->
         when (action) {
             is DashboardAction.UnplannedWorkoutClick -> vm.onAction(WorkoutAction.StartNewWorkout)
-            is DashboardAction.PlannedWorkoutClick -> vm.onAction(WorkoutAction.StartPlannedWorkout(action.workoutId))
+            // is DashboardAction.PlannedWorkoutClick -> vm.onAction(WorkoutAction.StartPlannedWorkout(action.workoutId))
             else -> {}
         }
         onAction(action)

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/exercise/CreateExerciseScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/exercise/CreateExerciseScreen.kt
@@ -81,8 +81,6 @@ fun CreateExerciseScreen(
                     ExerciseAction.ExerciseCreated(
                         Exercise(
                             "",
-                            // TODO add user id to exercise
-                            "",
                             name,
                             description,
                             primaryMuscle.selected,

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/exercise/ExerciseNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/exercise/ExerciseNavigation.kt
@@ -4,20 +4,16 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import io.github.jakubherr.gitfit.presentation.AddExerciseToPlanRoute
 import io.github.jakubherr.gitfit.presentation.AddExerciseToWorkoutRoute
 import io.github.jakubherr.gitfit.presentation.CreateExerciseRoute
 import io.github.jakubherr.gitfit.presentation.ExerciseDetailRoute
 import io.github.jakubherr.gitfit.presentation.ExerciseListRoute
-import io.github.jakubherr.gitfit.presentation.planning.PlanAction
-import io.github.jakubherr.gitfit.presentation.planning.PlanningViewModel
 import io.github.jakubherr.gitfit.presentation.workout.WorkoutAction
 import io.github.jakubherr.gitfit.presentation.workout.WorkoutViewModel
 import org.koin.compose.viewmodel.koinViewModel
 
 fun NavGraphBuilder.exerciseNavigation(
     navController: NavHostController,
-    planningViewModel: PlanningViewModel,
 ) {
     composable<ExerciseListRoute> {
         ExerciseListScreenRoot(
@@ -25,6 +21,7 @@ fun NavGraphBuilder.exerciseNavigation(
             onExerciseClick = { /* TODO navigate to exercise detail */ },
         )
     }
+
     composable<AddExerciseToWorkoutRoute> { backStackEntry ->
         val route: AddExerciseToWorkoutRoute = backStackEntry.toRoute()
         val workoutViewModel: WorkoutViewModel = koinViewModel()
@@ -33,18 +30,6 @@ fun NavGraphBuilder.exerciseNavigation(
             onCreateExerciseClick = { navController.navigate(CreateExerciseRoute) },
             onExerciseClick = { exercise ->
                 workoutViewModel.onAction(WorkoutAction.AddBlock(route.workoutId, exercise.id))
-                navController.popBackStack()
-            },
-        )
-    }
-
-    composable<AddExerciseToPlanRoute> { backstackEntry ->
-        val idx = backstackEntry.toRoute<AddExerciseToPlanRoute>().workoutIdx
-
-        ExerciseListScreenRoot(
-            onCreateExerciseClick = { navController.navigate(CreateExerciseRoute) },
-            onExerciseClick = { exercise ->
-                planningViewModel.onAction(PlanAction.AddExercise(idx, exercise))
                 navController.popBackStack()
             },
         )

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/exercise/ExerciseNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/exercise/ExerciseNavigation.kt
@@ -4,15 +4,21 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import io.github.jakubherr.gitfit.presentation.AddExerciseToPlanRoute
 import io.github.jakubherr.gitfit.presentation.AddExerciseToWorkoutRoute
 import io.github.jakubherr.gitfit.presentation.CreateExerciseRoute
 import io.github.jakubherr.gitfit.presentation.ExerciseDetailRoute
 import io.github.jakubherr.gitfit.presentation.ExerciseListRoute
+import io.github.jakubherr.gitfit.presentation.planning.PlanAction
+import io.github.jakubherr.gitfit.presentation.planning.PlanningViewModel
 import io.github.jakubherr.gitfit.presentation.workout.WorkoutAction
 import io.github.jakubherr.gitfit.presentation.workout.WorkoutViewModel
 import org.koin.compose.viewmodel.koinViewModel
 
-fun NavGraphBuilder.exerciseNavigation(navController: NavHostController) {
+fun NavGraphBuilder.exerciseNavigation(
+    navController: NavHostController,
+    planningViewModel: PlanningViewModel,
+) {
     composable<ExerciseListRoute> {
         ExerciseListScreenRoot(
             onCreateExerciseClick = { navController.navigate(CreateExerciseRoute) },
@@ -22,6 +28,7 @@ fun NavGraphBuilder.exerciseNavigation(navController: NavHostController) {
     composable<AddExerciseToWorkoutRoute> { backStackEntry ->
         val route: AddExerciseToWorkoutRoute = backStackEntry.toRoute()
         val workoutViewModel: WorkoutViewModel = koinViewModel()
+
         ExerciseListScreenRoot(
             onCreateExerciseClick = { navController.navigate(CreateExerciseRoute) },
             onExerciseClick = { exercise ->
@@ -30,6 +37,19 @@ fun NavGraphBuilder.exerciseNavigation(navController: NavHostController) {
             },
         )
     }
+
+    composable<AddExerciseToPlanRoute> { backstackEntry ->
+        val idx = backstackEntry.toRoute<AddExerciseToPlanRoute>().workoutIdx
+
+        ExerciseListScreenRoot(
+            onCreateExerciseClick = { navController.navigate(CreateExerciseRoute) },
+            onExerciseClick = { exercise ->
+                planningViewModel.onAction(PlanAction.AddExercise(idx, exercise))
+                navController.popBackStack()
+            },
+        )
+    }
+
     composable<ExerciseDetailRoute> {
         // TODO
     }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/exercise/ExerciseViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/exercise/ExerciseViewModel.kt
@@ -2,14 +2,16 @@ package io.github.jakubherr.gitfit.presentation.exercise
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import io.github.jakubherr.gitfit.data.repository.FirebaseAuthRepository
 import io.github.jakubherr.gitfit.domain.ExerciseRepository
 import io.github.jakubherr.gitfit.domain.model.Exercise
 import kotlinx.coroutines.launch
 
 class ExerciseViewModel(
     private val exerciseRepository: ExerciseRepository,
+    private val authRepository: FirebaseAuthRepository,
 ) : ViewModel() {
-    val flow = exerciseRepository.getAllExercises()
+    val flow = exerciseRepository.getDefaultExercises()
 
     fun onAction(action: ExerciseAction) {
         when (action) {
@@ -20,7 +22,7 @@ class ExerciseViewModel(
 
     private fun createExercise(exercise: Exercise) {
         viewModelScope.launch {
-            exerciseRepository.createExercise(exercise)
+            exerciseRepository.addCustomExercise(authRepository.currentUser.id, exercise)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/measurement/MeasurementScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/measurement/MeasurementScreen.kt
@@ -89,8 +89,6 @@ fun MeasurementScreenRoot(
 
             val measurement =
                 Measurement(
-                    id = "",
-                    userId = "",
                     date = Clock.System.todayIn(TimeZone.currentSystemDefault()),
                     measurements[0].value(),
                     measurements[1].value(),

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/measurement/MeasurementViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/measurement/MeasurementViewModel.kt
@@ -2,12 +2,14 @@ package io.github.jakubherr.gitfit.presentation.measurement
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import io.github.jakubherr.gitfit.data.repository.FirebaseAuthRepository
 import io.github.jakubherr.gitfit.domain.MeasurementRepository
 import io.github.jakubherr.gitfit.domain.model.Measurement
 import kotlinx.coroutines.launch
 
 class MeasurementViewModel(
     private val measurementRepository: MeasurementRepository,
+    private val authRepository: FirebaseAuthRepository,
 ) : ViewModel() {
     fun onAction(action: MeasurementAction) {
         when (action) {
@@ -16,8 +18,11 @@ class MeasurementViewModel(
     }
 
     private fun saveMeasurement(measurement: Measurement) {
+        val user = authRepository.currentUser
+        if (!user.loggedIn) return
+
         viewModelScope.launch {
-            measurementRepository.addMeasurement(measurement)
+            measurementRepository.addMeasurement(user.id, measurement)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
@@ -1,8 +1,11 @@
 package io.github.jakubherr.gitfit.presentation.planning
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -39,9 +42,11 @@ fun PlanCreationScreen(
         Text("Workout days")
         LazyColumn {
             items(plan.workouts) { workout ->
-                WorkoutListItem(workout) {
-                    onWorkoutSelected(workout.idx)
-                }
+                WorkoutListItem(
+                    workout,
+                    onClick = { onWorkoutSelected(workout.idx) },
+                    onDeleteClicked = { onAction(PlanAction.DeleteWorkout(workout))}
+                )
             }
         }
 
@@ -56,14 +61,23 @@ fun PlanCreationScreen(
             Text("Add workout day")
         }
 
-        Button({
-            onAction(PlanAction.SavePlan(planName))
-            onFinished() // TODO navigate only if plan saving was sucessfull
-        }) {
-            Text("Save plan")
-        }
-        Button({ /* TODO */ }) {
-            Text("Cancel")
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Button({
+                onAction(PlanAction.SavePlan(planName))
+                onFinished() // TODO navigate only if plan saving was sucessfull
+            }) {
+                Text("Save plan")
+            }
+
+            Button({
+                onAction(PlanAction.DiscardPlan)
+                onFinished()
+            }) {
+                Text("Discard plan")
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
@@ -13,10 +13,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.jakubherr.gitfit.domain.model.Plan
@@ -26,10 +22,8 @@ import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
 fun PlanCreationScreen(
     plan: Plan,
     modifier: Modifier = Modifier,
-    onSave: () -> Unit = {},
-    onDiscard: () -> Unit = {},
-    onWorkoutSelected: (Int) -> Unit = {},
     onAction: (PlanAction) -> Unit = {},
+    onWorkoutSelected: (Int) -> Unit = {},
 ) {
     Column(modifier.fillMaxSize()) {
         Text("Creating a new plan")
@@ -46,8 +40,8 @@ fun PlanCreationScreen(
             items(plan.workouts) { workout ->
                 WorkoutListItem(
                     workout,
-                    onClick = { onWorkoutSelected(workout.idx) },
-                    onDeleteClicked = { onAction(PlanAction.DeleteWorkout(workout))}
+                    onItemClicked = { onWorkoutSelected(workout.idx) },
+                    onActionClicked = { onAction(PlanAction.DeleteWorkout(workout))}
                 )
             }
         }
@@ -67,19 +61,9 @@ fun PlanCreationScreen(
             Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Button({
-                onAction(PlanAction.SavePlan)
-                onSave()
-            }) {
-                Text("Save plan")
-            }
+            Button({ onAction(PlanAction.SavePlan) }) { Text("Save plan") }
 
-            Button({
-                onAction(PlanAction.DiscardPlan)
-                onDiscard()
-            }) {
-                Text("Discard plan")
-            }
+            Button({ onAction(PlanAction.DiscardPlan) }) { Text("Discard plan") }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
@@ -26,16 +26,18 @@ import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
 fun PlanCreationScreen(
     plan: Plan,
     modifier: Modifier = Modifier,
-    onFinished: () -> Unit = {},
+    onSave: () -> Unit = {},
+    onDiscard: () -> Unit = {},
     onWorkoutSelected: (Int) -> Unit = {},
     onAction: (PlanAction) -> Unit = {},
 ) {
-    var planName by rememberSaveable { mutableStateOf("") }
-
     Column(modifier.fillMaxSize()) {
         Text("Creating a new plan")
         Text("Plan name")
-        TextField(value = planName, onValueChange = { planName = it })
+        TextField(
+            value = plan.name,
+            onValueChange = { onAction(PlanAction.RenamePlan(it)) }
+        )
 
         Spacer(Modifier.width(16.dp))
 
@@ -66,15 +68,15 @@ fun PlanCreationScreen(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Button({
-                onAction(PlanAction.SavePlan(planName))
-                onFinished() // TODO navigate only if plan saving was sucessfull
+                onAction(PlanAction.SavePlan)
+                onSave()
             }) {
                 Text("Save plan")
             }
 
             Button({
                 onAction(PlanAction.DiscardPlan)
-                onFinished()
+                onDiscard()
             }) {
                 Text("Discard plan")
             }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
@@ -1,0 +1,63 @@
+package io.github.jakubherr.gitfit.presentation.planning
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import io.github.jakubherr.gitfit.domain.model.Plan
+import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
+
+@Composable
+fun PlanCreationScreen(
+    plan: Plan,
+    modifier: Modifier = Modifier,
+    onFinished: () -> Unit = {},
+    onWorkoutSelected: (Int) -> Unit = {},
+    onAction: (PlanAction) -> Unit = {},
+) {
+    var planName by remember { mutableStateOf("") }
+
+    Column(modifier.fillMaxSize()) {
+        Text("Creating a new plan")
+        Text("Plan name")
+        TextField(value = plan.name, onValueChange = { planName = it })
+
+        LazyColumn {
+            items(plan.workouts) { workout ->
+                PlanListItem(workout) {
+                    onWorkoutSelected(workout.idx)
+                }
+            }
+        }
+
+        Button({
+            val workout = WorkoutPlan(
+                "New workout",
+                plan.workouts.size,
+                emptyList(),
+            )
+            onAction(PlanAction.AddWorkout(workout))
+        }) {
+            Text("Add workout day")
+        }
+
+        Button({
+            onAction(PlanAction.SavePlan)
+            onFinished()
+        }) {
+            Text("Save plan")
+        }
+        Button({ /* TODO */ }) {
+            Text("Cancel")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanCreationScreen.kt
@@ -1,7 +1,9 @@
 package io.github.jakubherr.gitfit.presentation.planning
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
@@ -10,9 +12,10 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import io.github.jakubherr.gitfit.domain.model.Plan
 import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
 
@@ -24,16 +27,19 @@ fun PlanCreationScreen(
     onWorkoutSelected: (Int) -> Unit = {},
     onAction: (PlanAction) -> Unit = {},
 ) {
-    var planName by remember { mutableStateOf("") }
+    var planName by rememberSaveable { mutableStateOf("") }
 
     Column(modifier.fillMaxSize()) {
         Text("Creating a new plan")
         Text("Plan name")
-        TextField(value = plan.name, onValueChange = { planName = it })
+        TextField(value = planName, onValueChange = { planName = it })
 
+        Spacer(Modifier.width(16.dp))
+
+        Text("Workout days")
         LazyColumn {
             items(plan.workouts) { workout ->
-                PlanListItem(workout) {
+                WorkoutListItem(workout) {
                     onWorkoutSelected(workout.idx)
                 }
             }
@@ -51,8 +57,8 @@ fun PlanCreationScreen(
         }
 
         Button({
-            onAction(PlanAction.SavePlan)
-            onFinished()
+            onAction(PlanAction.SavePlan(planName))
+            onFinished() // TODO navigate only if plan saving was sucessfull
         }) {
             Text("Save plan")
         }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanDetailScreen.kt
@@ -1,0 +1,65 @@
+package io.github.jakubherr.gitfit.presentation.planning
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.github.jakubherr.gitfit.domain.model.Plan
+import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
+
+@Composable
+fun PlanDetailScreen(
+    plan: Plan,
+    modifier: Modifier = Modifier,
+    onWorkoutSelected: (WorkoutPlan) -> Unit = {},
+    onPlanSelected: () -> Unit = {}, // TODO User can add a predefined plan to his plans, where he can edit it etc.
+    onAction: (PlanAction) -> Unit = {},
+) {
+    Column(modifier.fillMaxSize().padding(16.dp)) {
+        Row(
+            Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(plan.name.ifBlank { "Unnamed plan" })
+
+            Row {
+                IconButton({ onAction(PlanAction.EditPlan(plan)) }) {
+                    Icon(Icons.Default.Edit, "")
+                }
+                // TODO: "are you sure?" dialog
+                IconButton({ onAction(PlanAction.DeletePlan(plan.id)) }) {
+                    Icon(Icons.Default.Delete, "")
+                }
+            }
+
+        }
+
+        LazyColumn {
+            items(plan.workouts) { workout ->
+                WorkoutListItem(
+                    workout,
+                    onActionClicked = { onWorkoutSelected(workout) },
+                    actionSlot = { Icon(Icons.Default.PlayArrow, "") }
+                )
+            }
+        }
+    }
+    
+    // nice to have: user has the ability to schedule a workout for a certain date
+}

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -34,11 +33,8 @@ fun PlanOverviewScreenRoot(
     onCreateNewPlan: () -> Unit = {},
     onPlanSelected: (Plan) -> Unit = {},
 ) {
-    val userWorkouts by vm.userWorkouts.collectAsStateWithLifecycle(emptyList())
     val userPlans by vm.userPlans.collectAsStateWithLifecycle(emptyList())
     val predefinedPlans by vm.predefinedPlans.collectAsStateWithLifecycle(emptyList())
-
-    println("DBG: number of user workout plans: ${userWorkouts.size}")
 
     Column(modifier.fillMaxSize()) {
 
@@ -93,34 +89,6 @@ fun PlanListItem(
     // list of workout days it contains?
     // for each workout day list name and exercises? (limited to fit card)
 
-}
-
-@Composable
-fun PlanDetailScreen(
-    plan: Plan,
-    modifier: Modifier = Modifier,
-    onWorkoutSelected: (WorkoutPlan) -> Unit = {},
-    onPlanSelected: () -> Unit = {}, // TODO User can add a predefined plan to his plans, where he can edit it etc.
-) {
-    // TODO: Detail that is shown when a plan is selected from a list
-    Column(modifier.fillMaxSize()) {
-        Text(plan.name.ifBlank { "Unnamed plan" } )
-
-        LazyColumn {
-            items(plan.workouts) { workout ->
-                WorkoutListItem(
-                    workout,
-                    onActionClicked = { onWorkoutSelected(workout) },
-                    actionSlot = { Icon(Icons.Default.PlayArrow, "") }
-                )
-            }
-        }
-    }
-
-    //  should show a name, some metadata and a list of workouts that are part of the plan
-    //  user should have the ability to start tracking a workout selected by clicking
-    //  user should be able to edit the plan
-    // nice to have: user has the ability to schedule a workout for a certain date
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -18,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.jakubherr.gitfit.domain.model.Plan
 import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
@@ -39,11 +42,16 @@ fun PlanOverviewScreenRoot(
 
     Column(modifier.fillMaxSize()) {
 
-        LazyColumn {
+        LazyColumn(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
             item { Text("Your plans") }
             items(userPlans) { plan ->
-                PlanListItem(plan) {
-                    // TODO ask to start selected workout and execute choice
+                PlanListItem(
+                    plan,
+                    modifier = Modifier.padding(16.dp)
+                ) {
                     onPlanSelected(plan)
                 }
             }
@@ -73,7 +81,7 @@ fun PlanListItem(
     // TODO card for a complete plan
     // name of plan
     Card(onPlanClicked) {
-        Column(Modifier.fillMaxWidth()) {
+        Column(modifier.fillMaxWidth()) {
             Text(plan.name)
             plan.workouts.forEach { workout ->
                 Text(workout.name, fontWeight = FontWeight.SemiBold)
@@ -102,7 +110,8 @@ fun PlanDetailScreen(
             items(plan.workouts) { workout ->
                 WorkoutListItem(
                     workout,
-                    onClick = { }
+                    onActionClicked = { onWorkoutSelected(workout) },
+                    actionSlot = { Icon(Icons.Default.PlayArrow, "") }
                 )
             }
         }
@@ -118,18 +127,23 @@ fun PlanDetailScreen(
 fun WorkoutListItem(
     workout: WorkoutPlan,
     modifier: Modifier = Modifier,
-    onClick: () -> Unit = {},
-    onDeleteClicked: () -> Unit = {},
+    onItemClicked: () -> Unit = {},
+    actionSlot: @Composable () -> Unit = { Icon(Icons.Default.Delete, "") },
+    onActionClicked: () -> Unit = {},
 ) {
-    Card(onClick) {
+    Card(
+        onItemClicked,
+        modifier.padding(16.dp)
+    ) {
         Column {
             Row(
                 Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 Text(workout.name)
-                IconButton(onDeleteClicked) {
-                    Icon(Icons.Default.Delete, "")
+
+                IconButton(onActionClicked) {
+                    actionSlot()
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
@@ -1,0 +1,58 @@
+package io.github.jakubherr.gitfit.presentation.planning
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
+import org.koin.compose.viewmodel.koinViewModel
+
+// use case: plan workouts to be performed in the future (weeks, months)
+@Composable
+fun PlanOverviewScreenRoot(
+    vm: PlanningViewModel = koinViewModel(),
+    modifier: Modifier = Modifier,
+    onCreateNewPlan: () -> Unit = {},
+) {
+    val userWorkouts by vm.userWorkouts.collectAsStateWithLifecycle(emptyList())
+
+    Column(modifier.fillMaxSize()) {
+        Text("Your plans")
+        LazyColumn {
+            items(userWorkouts) { wo ->
+                // TODO UI card for workout
+                Text(wo.blocks.joinToString())
+            }
+        }
+
+        Text("Predefined plans")
+        LazyColumn {
+            items(3) { idx -> Text("Predefined plan #$idx") }
+        }
+
+        Button(onCreateNewPlan) {
+            Text("Create a new plan")
+        }
+    }
+}
+
+@Composable
+fun PlanListItem(
+    workout: WorkoutPlan,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Card(onClick) {
+        Column {
+            Text(workout.name)
+            Text(workout.blocks.joinToString())
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
@@ -1,12 +1,18 @@
 package io.github.jakubherr.gitfit.presentation.planning
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -113,10 +119,19 @@ fun WorkoutListItem(
     workout: WorkoutPlan,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
+    onDeleteClicked: () -> Unit = {},
 ) {
     Card(onClick) {
         Column {
-            Text(workout.name)
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(workout.name)
+                IconButton(onDeleteClicked) {
+                    Icon(Icons.Default.Delete, "")
+                }
+            }
 
             val exercises = workout.blocks.map { it.exercise.name }
             exercises.forEach {

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanOverviewScreen.kt
@@ -2,6 +2,7 @@ package io.github.jakubherr.gitfit.presentation.planning
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
@@ -10,7 +11,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.jakubherr.gitfit.domain.model.Plan
 import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -20,39 +23,105 @@ fun PlanOverviewScreenRoot(
     vm: PlanningViewModel = koinViewModel(),
     modifier: Modifier = Modifier,
     onCreateNewPlan: () -> Unit = {},
+    onPlanSelected: (Plan) -> Unit = {},
 ) {
     val userWorkouts by vm.userWorkouts.collectAsStateWithLifecycle(emptyList())
+    val userPlans by vm.userPlans.collectAsStateWithLifecycle(emptyList())
+    val predefinedPlans by vm.predefinedPlans.collectAsStateWithLifecycle(emptyList())
+
+    println("DBG: number of user workout plans: ${userWorkouts.size}")
 
     Column(modifier.fillMaxSize()) {
-        Text("Your plans")
+
         LazyColumn {
-            items(userWorkouts) { wo ->
-                // TODO UI card for workout
-                Text(wo.blocks.joinToString())
+            item { Text("Your plans") }
+            items(userPlans) { plan ->
+                PlanListItem(plan) {
+                    // TODO ask to start selected workout and execute choice
+                    onPlanSelected(plan)
+                }
             }
-        }
 
-        Text("Predefined plans")
-        LazyColumn {
-            items(3) { idx -> Text("Predefined plan #$idx") }
-        }
+            item { Text("Predefined plans") }
+            items(predefinedPlans) { plan ->
+                PlanListItem(plan) {
 
-        Button(onCreateNewPlan) {
-            Text("Create a new plan")
+                }
+            }
+
+            item {
+                Button(onCreateNewPlan) {
+                    Text("Create a new plan")
+                }
+            }
         }
     }
 }
 
 @Composable
 fun PlanListItem(
+    plan: Plan,
+    modifier: Modifier = Modifier,
+    onPlanClicked: () -> Unit = {}
+) {
+    // TODO card for a complete plan
+    // name of plan
+    Card(onPlanClicked) {
+        Column(Modifier.fillMaxWidth()) {
+            Text(plan.name)
+            plan.workouts.forEach { workout ->
+                Text(workout.name, fontWeight = FontWeight.SemiBold)
+                val exerciseList = workout.blocks.joinToString { it.exercise.name }
+                Text("-\t$exerciseList")
+            }
+        }
+    }
+    // list of workout days it contains?
+    // for each workout day list name and exercises? (limited to fit card)
+
+}
+
+@Composable
+fun PlanDetailScreen(
+    plan: Plan,
+    modifier: Modifier = Modifier,
+    onWorkoutSelected: (WorkoutPlan) -> Unit = {},
+    onPlanSelected: () -> Unit = {}, // TODO User can add a predefined plan to his plans, where he can edit it etc.
+) {
+    // TODO: Detail that is shown when a plan is selected from a list
+    Column(modifier.fillMaxSize()) {
+        Text(plan.name.ifBlank { "Unnamed plan" } )
+
+        LazyColumn {
+            items(plan.workouts) { workout ->
+                WorkoutListItem(
+                    workout,
+                    onClick = { }
+                )
+            }
+        }
+    }
+
+    //  should show a name, some metadata and a list of workouts that are part of the plan
+    //  user should have the ability to start tracking a workout selected by clicking
+    //  user should be able to edit the plan
+    // nice to have: user has the ability to schedule a workout for a certain date
+}
+
+@Composable
+fun WorkoutListItem(
     workout: WorkoutPlan,
     modifier: Modifier = Modifier,
-    onClick: () -> Unit
+    onClick: () -> Unit = {},
 ) {
     Card(onClick) {
         Column {
             Text(workout.name)
-            Text(workout.blocks.joinToString())
+
+            val exercises = workout.blocks.map { it.exercise.name }
+            exercises.forEach {
+                Text(it)
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -48,7 +49,8 @@ fun PlanWorkoutDetailScreen(
             PlanBlockItem(
                 block,
                 onAddSetClicked = { onAction(PlanAction.AddSet(workout, block)) },
-                onValidSetEntered = { onAction(PlanAction.EditSet(workout, block, it)) }
+                onValidSetEntered = { onAction(PlanAction.EditSet(workout, block, it)) },
+                onDeleteSet =  { onAction(PlanAction.RemoveSet(workout, block, it))}
             )
         }
         item {
@@ -66,6 +68,7 @@ fun PlanBlockItem(
     modifier: Modifier = Modifier,
     onAddSetClicked: () -> Unit = {},
     onValidSetEntered: (Series) -> Unit = {},
+    onDeleteSet: (Series) -> Unit = {},
 ) {
     Card(Modifier.fillMaxWidth().padding(16.dp)) {
         Column(Modifier.padding(8.dp)) {
@@ -80,9 +83,11 @@ fun PlanBlockItem(
                 SetHeader()
                 Spacer(Modifier.height(16.dp))
                 block.series.forEachIndexed { idx, set ->
-                    PlanSetInput(idx + 1, set) {
-                        onValidSetEntered(it)
-                    }
+                    PlanSetInput(
+                        idx + 1, set,
+                        onValidSetEntered = { onValidSetEntered(it) },
+                        onDeleteSet = { onDeleteSet(set) }
+                    )
                 }
             }
             Spacer(modifier.height(8.dp))
@@ -98,7 +103,8 @@ fun PlanSetInput(
     index: Int,
     set: Series,
     modifier: Modifier = Modifier,
-    onValidSetEntered: (Series) -> Unit,
+    onValidSetEntered: (Series) -> Unit = {},
+    onDeleteSet: () -> Unit = {}
 ) {
     var weight by remember { mutableStateOf(set.weight?.toString() ?: "") }
     var reps by remember { mutableStateOf(set.repetitions?.toString() ?: "") }
@@ -130,5 +136,9 @@ fun PlanSetInput(
                 }
             }
         )
+
+        IconButton(onDeleteSet) {
+            Icon(Icons.Default.Delete, "")
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
@@ -17,11 +17,13 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,6 +45,7 @@ fun PlanWorkoutDetailScreen(
     modifier: Modifier = Modifier,
     onAction: (PlanAction) -> Unit = {},
     onAddExerciseClick: (Int) -> Unit = {},
+    onSave: () -> Unit = {},
 ) {
     LazyColumn {
         items(workout.blocks) { block ->
@@ -57,7 +60,10 @@ fun PlanWorkoutDetailScreen(
             Button(onClick = { onAddExerciseClick(workout.idx) }) { Text("Add exercise") }
         }
         item {
-            Button({ onAction(PlanAction.SaveWorkout(workout)) }) { Text("Save workout") }
+            Button({
+                onAction(PlanAction.SaveWorkout(workout))
+                onSave()
+            }) { Text("Save workout") }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
@@ -125,10 +125,16 @@ fun PlanSetInput(
         NumberInputField(
             weight,
             isError = !weight.isPositiveDouble(),
-            onValueChange = {
-                weight = it
-                if (weight.isPositiveDouble() && reps.isPositiveLong()) {
-                    onValidSetEntered(set.copy(weight = weight.toLong(), repetitions = reps.toLong()))
+            onValueChange = { newWeight ->
+                // limits the number of decimal points to 2
+                val decimals = newWeight.substringAfter(".", "")
+
+                if (decimals.length <= 2) {
+                    weight = newWeight
+
+                    if (weight.isPositiveDouble() && reps.isPositiveLong()) {
+                        onValidSetEntered(set.copy(weight = weight.toDouble(), repetitions = reps.toLong()))
+                    }
                 }
             }
         )
@@ -138,7 +144,7 @@ fun PlanSetInput(
             onValueChange = {
                 reps = it
                 if (weight.isPositiveDouble() && reps.isPositiveLong()) {
-                    onValidSetEntered(set.copy(weight = weight.toLong(), repetitions = reps.toLong()))
+                    onValidSetEntered(set.copy(weight = weight.toDouble(), repetitions = reps.toLong()))
                 }
             }
         )

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,7 +17,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,134 +25,26 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import gitfit.composeapp.generated.resources.Res
 import gitfit.composeapp.generated.resources.add_set
-import io.github.jakubherr.gitfit.domain.isPositiveLong
 import io.github.jakubherr.gitfit.domain.model.Block
-import io.github.jakubherr.gitfit.domain.model.Plan
 import io.github.jakubherr.gitfit.domain.model.Series
 import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
 import io.github.jakubherr.gitfit.domain.model.mockSeries
-import io.github.jakubherr.gitfit.presentation.exercise.ExerciseListScreenRoot
-import io.github.jakubherr.gitfit.presentation.workout.CheckableSetInput
 import io.github.jakubherr.gitfit.presentation.workout.NumberInputField
 import io.github.jakubherr.gitfit.presentation.workout.SetHeader
-import io.github.jakubherr.gitfit.presentation.workout.WorkoutAction
 import org.jetbrains.compose.resources.stringResource
-import org.koin.compose.viewmodel.koinViewModel
-
-// use case: plan workouts to be performed in the future (weeks, months)
-@Composable
-fun PlanningScreenRoot(
-    vm: PlanningViewModel = koinViewModel(),
-    modifier: Modifier = Modifier
-) {
-    var creatingPlan by remember { mutableStateOf(false) }
-    val userWorkouts by vm.userWorkouts.collectAsStateWithLifecycle(emptyList())
-
-    Column(modifier.fillMaxSize()) {
-        if (!creatingPlan) {
-            Text("Your plans")
-            LazyColumn {
-                items(userWorkouts) { wo ->
-                    // TODO UI card for workout
-                    Text(wo.blocks.joinToString())
-                }
-            }
-
-            Text("Predefined plans")
-            LazyColumn {
-                items(3) { idx -> Text("Predefined plan #$idx") }
-            }
-
-            Button({ creatingPlan = true }) {
-                Text("Create a new plan")
-            }
-        } else {
-            PlanCreation(
-                vm.plan,
-                onFinished = { creatingPlan = false }
-            ) {
-                vm.onAction(it)
-            }
-        }
-    }
-
-}
 
 @Composable
-fun PlanCreation(
-    plan: Plan,
-    modifier: Modifier = Modifier,
-    onFinished: () -> Unit = {},
-    onAction: (PlanAction) -> Unit = {},
-) {
-    var planName by remember { mutableStateOf("") }
-    var selectedWorkoutIdx by remember { mutableStateOf<Int?>(null) }
-
-    if (selectedWorkoutIdx == null) {
-        Text("Creating a new plan")
-        Text("Plan name")
-        TextField(value = plan.name, onValueChange = { planName = it })
-
-        LazyColumn {
-            items(plan.workouts) { workout ->
-                PlanListItem(workout) {
-                    selectedWorkoutIdx = workout.idx
-                }
-            }
-        }
-
-        Button({
-            val workout = WorkoutPlan(
-                "New workout",
-                plan.workouts.size,
-                emptyList(),
-            )
-
-            onAction(PlanAction.AddWorkout(workout))
-        }) {
-            Text("Add workout day")
-        }
-        Button({ /* TODO */ }) {
-            Text("Save plan")
-        }
-        Button({ /* TODO */ }) {
-            Text("Cancel")
-        }
-    } else {
-        PlanWorkoutDetail(plan.workouts[selectedWorkoutIdx!!]) {
-            onAction(it)
-        }
-    }
-}
-
-@Composable
-fun PlanListItem(
-    workout: WorkoutPlan,
-    modifier: Modifier = Modifier,
-    onClick: () -> Unit
-) {
-    Card(onClick) {
-        Column {
-            Text(workout.name)
-            Text(workout.blocks.joinToString())
-        }
-    }
-}
-
-@Composable
-fun PlanWorkoutDetail(
+fun PlanWorkoutDetailScreen(
     workout: WorkoutPlan,
     modifier: Modifier = Modifier,
     onAction: (PlanAction) -> Unit = {},
+    onAddExerciseClick: (Int) -> Unit = {},
 ) {
-    var selectExercise by remember { mutableStateOf(false) }
-
     LazyColumn {
         item {
-            Button({ selectExercise = true }) { Text("Add exercise") }
+            Button(onClick = { onAddExerciseClick(workout.idx) }) { Text("Add exercise") }
         }
         items(workout.blocks) { block ->
             PlanBlockItem(
@@ -166,17 +56,6 @@ fun PlanWorkoutDetail(
         item {
             Button({ onAction(PlanAction.SaveWorkout(workout)) }) { Text("Save workout") }
         }
-    }
-
-    if (selectExercise) {
-        ExerciseListScreenRoot(
-            onExerciseClick = { exercise ->
-                println("DBG: $exercise selected")
-
-                onAction(PlanAction.AddExercise(workout, exercise))
-                selectExercise = false
-            }
-        )
     }
 }
 
@@ -199,7 +78,7 @@ fun PlanBlockItem(
                 SetHeader()
                 Spacer(Modifier.height(16.dp))
                 block.series.forEachIndexed { idx, set ->
-                    PlanSetInput(idx+1, set)
+                    PlanSetInput(idx + 1, set)
                 }
             }
             Spacer(modifier.height(8.dp))
@@ -230,4 +109,3 @@ fun PlanSetInput(
         NumberInputField(reps, onValueChange = { reps = it })
     }
 }
-

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanWorkoutDetailScreen.kt
@@ -53,7 +53,8 @@ fun PlanWorkoutDetailScreen(
                 block,
                 onAddSetClicked = { onAction(PlanAction.AddSet(workout, block)) },
                 onValidSetEntered = { onAction(PlanAction.EditSet(workout, block, it)) },
-                onDeleteSet =  { onAction(PlanAction.RemoveSet(workout, block, it))}
+                onDeleteSet =  { onAction(PlanAction.RemoveSet(workout, block, it)) },
+                onDeleteExercise = { onAction(PlanAction.RemoveExercise(workout, block)) },
             )
         }
         item {
@@ -75,13 +76,14 @@ fun PlanBlockItem(
     onAddSetClicked: () -> Unit = {},
     onValidSetEntered: (Series) -> Unit = {},
     onDeleteSet: (Series) -> Unit = {},
+    onDeleteExercise: (Block) -> Unit = {},
 ) {
     Card(Modifier.fillMaxWidth().padding(16.dp)) {
         Column(Modifier.padding(8.dp)) {
             Row {
                 Text(block.exercise.name, style = MaterialTheme.typography.titleLarge)
-                IconButton({}) {
-                    Icon(Icons.Default.MoreVert, "")
+                IconButton({ onDeleteExercise(block) }) {
+                    Icon(Icons.Default.Delete, "")
                 }
             }
             Spacer(Modifier.height(16.dp))

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
@@ -13,9 +13,13 @@ import io.github.jakubherr.gitfit.presentation.PlanCreationRoute
 import io.github.jakubherr.gitfit.presentation.PlanDetailRoute
 import io.github.jakubherr.gitfit.presentation.PlanOverviewRoute
 import io.github.jakubherr.gitfit.presentation.PlanningWorkoutRoute
+import io.github.jakubherr.gitfit.presentation.WorkoutInProgressRoute
 import io.github.jakubherr.gitfit.presentation.exercise.ExerciseListScreenRoot
+import io.github.jakubherr.gitfit.presentation.workout.WorkoutAction
+import io.github.jakubherr.gitfit.presentation.workout.WorkoutViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import org.koin.compose.viewmodel.koinViewModel
 
 fun NavGraphBuilder.planningGraph(
     navController: NavHostController,
@@ -45,13 +49,17 @@ fun NavGraphBuilder.planningGraph(
         // TODO differentiate user and predefined plan
         val userPlan = userPlans.value.find { it.id == planId }
 
+        val workoutViewModel: WorkoutViewModel = koinViewModel()
+
         userPlan?.let { plan ->
             PlanDetailScreen(
                 plan,
-                onWorkoutSelected = {
-                /* TODO navigation event that will start a new workout from plan */
-                    // should handle edge case where user already has a workout in progress
-                    println("DBG: Plan selected")
+                onWorkoutSelected = { workout ->
+                    // TODO should handle edge case where user already has a workout in progress
+                    println("DBG: Plan selected: ${plan.id}, workout index ${workout.idx}")
+                    workoutViewModel.onAction(WorkoutAction.StartPlannedWorkout(plan.id, workout.idx))
+                    navController.navigate(WorkoutInProgressRoute)
+
                 }
             )
         }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
@@ -47,7 +47,12 @@ fun NavGraphBuilder.planningGraph(
 
         userPlan?.let { plan ->
             PlanDetailScreen(
-                plan
+                plan,
+                onWorkoutSelected = {
+                /* TODO navigation event that will start a new workout from plan */
+                    // should handle edge case where user already has a workout in progress
+                    println("DBG: Plan selected")
+                }
             )
         }
     }
@@ -69,12 +74,17 @@ fun NavGraphBuilder.planningGraph(
 
         PlanCreationScreen(
             viewModel.plan,
-            onAction = { viewModel.onAction(it) },
+            onAction = { action ->
+                viewModel.onAction(action)
+                when (action) {
+                    PlanAction.DiscardPlan -> navController.popBackStack()
+                    PlanAction.SavePlan -> handleError(viewModel.error, scope)
+                    else -> {}
+                }
+           },
             onWorkoutSelected = { workoutIdx ->
                 navController.navigate(PlanningWorkoutRoute(workoutIdx))
             },
-            onSave = { handleError(viewModel.error, scope) },
-            onDiscard = { navController.popBackStack() }
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
@@ -1,0 +1,45 @@
+package io.github.jakubherr.gitfit.presentation.planning
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import io.github.jakubherr.gitfit.presentation.AddExerciseToPlanRoute
+import io.github.jakubherr.gitfit.presentation.PlanCreationRoute
+import io.github.jakubherr.gitfit.presentation.PlanOverviewRoute
+import io.github.jakubherr.gitfit.presentation.PlanningWorkoutRoute
+
+fun NavGraphBuilder.planningGraph(
+    navController: NavHostController,
+    viewModel: PlanningViewModel,
+) {
+    composable<PlanOverviewRoute> {
+        PlanOverviewScreenRoot(
+            vm = viewModel,
+            onCreateNewPlan = { navController.navigate(PlanCreationRoute) }
+        )
+    }
+
+    composable<PlanCreationRoute> {
+        PlanCreationScreen(
+            viewModel.plan,
+            onAction = { viewModel.onAction(it) },
+            onWorkoutSelected = { workoutIdx ->
+                navController.navigate(PlanningWorkoutRoute(workoutIdx))
+            },
+            onFinished = { navController.popBackStack() }
+        )
+    }
+
+    composable<PlanningWorkoutRoute> { backstackEntry ->
+        val idx = backstackEntry.toRoute<PlanningWorkoutRoute>().workoutIdx
+
+        PlanWorkoutDetailScreen(
+            workout = viewModel.plan.workouts[idx],
+            onAction = { viewModel.onAction(it) },
+            onAddExerciseClick = { workoutIdx ->
+                navController.navigate(AddExerciseToPlanRoute(workoutIdx))
+            }
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
@@ -1,13 +1,17 @@
 package io.github.jakubherr.gitfit.presentation.planning
 
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import io.github.jakubherr.gitfit.presentation.AddExerciseToPlanRoute
+import io.github.jakubherr.gitfit.presentation.CreateExerciseRoute
 import io.github.jakubherr.gitfit.presentation.PlanCreationRoute
+import io.github.jakubherr.gitfit.presentation.PlanDetailRoute
 import io.github.jakubherr.gitfit.presentation.PlanOverviewRoute
 import io.github.jakubherr.gitfit.presentation.PlanningWorkoutRoute
+import io.github.jakubherr.gitfit.presentation.exercise.ExerciseListScreenRoot
 
 fun NavGraphBuilder.planningGraph(
     navController: NavHostController,
@@ -16,7 +20,34 @@ fun NavGraphBuilder.planningGraph(
     composable<PlanOverviewRoute> {
         PlanOverviewScreenRoot(
             vm = viewModel,
-            onCreateNewPlan = { navController.navigate(PlanCreationRoute) }
+            onCreateNewPlan = { navController.navigate(PlanCreationRoute) },
+            onPlanSelected = { navController.navigate(PlanDetailRoute(it.id)) }
+        )
+    }
+
+    composable<PlanDetailRoute> { backstackEntry ->
+        val planId = backstackEntry.toRoute<PlanDetailRoute>().planId
+        val userPlans = viewModel.userPlans.collectAsStateWithLifecycle(emptyList())
+
+        // TODO differentiate user and predefined plan
+        val userPlan = userPlans.value.find { it.id == planId }
+
+        userPlan?.let { plan ->
+            PlanDetailScreen(
+                plan
+            )
+        }
+    }
+
+    composable<AddExerciseToPlanRoute> { backstackEntry ->
+        val idx = backstackEntry.toRoute<AddExerciseToPlanRoute>().workoutIdx
+
+        ExerciseListScreenRoot(
+            onCreateExerciseClick = { navController.navigate(CreateExerciseRoute) },
+            onExerciseClick = { exercise ->
+                viewModel.onAction(PlanAction.AddExercise(idx, exercise))
+                navController.popBackStack()
+            },
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningNavigation.kt
@@ -60,6 +60,11 @@ fun NavGraphBuilder.planningGraph(
                     workoutViewModel.onAction(WorkoutAction.StartPlannedWorkout(plan.id, workout.idx))
                     navController.navigate(WorkoutInProgressRoute)
 
+                },
+                onAction = { action ->
+                    viewModel.onAction(action)
+                    if (action is PlanAction.DeletePlan) navController.popBackStack()
+                    if (action is PlanAction.EditPlan) navController.navigate(PlanCreationRoute)
                 }
             )
         }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningScreen.kt
@@ -1,11 +1,22 @@
 package io.github.jakubherr.gitfit.presentation.planning
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -13,15 +24,24 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import gitfit.composeapp.generated.resources.Res
+import gitfit.composeapp.generated.resources.add_set
+import io.github.jakubherr.gitfit.domain.isPositiveLong
+import io.github.jakubherr.gitfit.domain.model.Block
 import io.github.jakubherr.gitfit.domain.model.Plan
-import io.github.jakubherr.gitfit.domain.model.Workout
+import io.github.jakubherr.gitfit.domain.model.Series
 import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
+import io.github.jakubherr.gitfit.domain.model.mockSeries
 import io.github.jakubherr.gitfit.presentation.exercise.ExerciseListScreenRoot
-import io.github.jakubherr.gitfit.presentation.workout.BlockItem
-import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.todayIn
+import io.github.jakubherr.gitfit.presentation.workout.CheckableSetInput
+import io.github.jakubherr.gitfit.presentation.workout.NumberInputField
+import io.github.jakubherr.gitfit.presentation.workout.SetHeader
+import io.github.jakubherr.gitfit.presentation.workout.WorkoutAction
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
 // use case: plan workouts to be performed in the future (weeks, months)
@@ -31,12 +51,16 @@ fun PlanningScreenRoot(
     modifier: Modifier = Modifier
 ) {
     var creatingPlan by remember { mutableStateOf(false) }
+    val userWorkouts by vm.userWorkouts.collectAsStateWithLifecycle(emptyList())
 
     Column(modifier.fillMaxSize()) {
         if (!creatingPlan) {
             Text("Your plans")
             LazyColumn {
-                items(3) { idx -> Text("Plan #$idx") }
+                items(userWorkouts) { wo ->
+                    // TODO UI card for workout
+                    Text(wo.blocks.joinToString())
+                }
             }
 
             Text("Predefined plans")
@@ -56,6 +80,7 @@ fun PlanningScreenRoot(
             }
         }
     }
+
 }
 
 @Composable
@@ -127,20 +152,19 @@ fun PlanWorkoutDetail(
 ) {
     var selectExercise by remember { mutableStateOf(false) }
 
-    Text("Selected workout: $workout")
-
-    Button({ selectExercise = true}) {
-        Text("Add exercise")
-    }
-
     LazyColumn {
+        item {
+            Button({ selectExercise = true }) { Text("Add exercise") }
+        }
         items(workout.blocks) { block ->
-            BlockItem(
+            PlanBlockItem(
                 block,
-                onAction = { onAction(PlanAction.RemoveExercise(workout, block)) }
             ) {
                 onAction(PlanAction.AddSet(workout, block))
             }
+        }
+        item {
+            Button({ onAction(PlanAction.SaveWorkout(workout)) }) { Text("Save workout") }
         }
     }
 
@@ -155,3 +179,55 @@ fun PlanWorkoutDetail(
         )
     }
 }
+
+@Composable
+fun PlanBlockItem(
+    block: Block,
+    modifier: Modifier = Modifier,
+    onAddSetClicked: () -> Unit = {},
+) {
+    Card(Modifier.fillMaxWidth().padding(16.dp)) {
+        Column(Modifier.padding(8.dp)) {
+            Row {
+                Text(block.exercise.name, style = MaterialTheme.typography.titleLarge)
+                IconButton({}) {
+                    Icon(Icons.Default.MoreVert, "")
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+            Column {
+                SetHeader()
+                Spacer(Modifier.height(16.dp))
+                block.series.forEachIndexed { idx, set ->
+                    PlanSetInput(idx+1, set)
+                }
+            }
+            Spacer(modifier.height(8.dp))
+            Button(onClick = onAddSetClicked) {
+                Text(stringResource(Res.string.add_set))
+            }
+        }
+    }
+}
+
+@Composable
+fun PlanSetInput(
+    index: Int,
+    set: Series = mockSeries,
+    modifier: Modifier = Modifier,
+) {
+    var weight by remember { mutableStateOf(set.weight?.toString() ?: "") }
+    var reps by remember { mutableStateOf(set.repetitions?.toString() ?: "") }
+
+    Row(
+        modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(index.toString())
+
+        NumberInputField(weight, onValueChange = { weight = it })
+        NumberInputField(reps, onValueChange = { reps = it })
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningScreen.kt
@@ -1,9 +1,158 @@
 package io.github.jakubherr.gitfit.presentation.planning
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import io.github.jakubherr.gitfit.domain.model.Plan
+import io.github.jakubherr.gitfit.domain.model.Workout
+import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
+import io.github.jakubherr.gitfit.presentation.exercise.ExerciseListScreenRoot
+import io.github.jakubherr.gitfit.presentation.workout.BlockItem
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import org.koin.compose.viewmodel.koinViewModel
 
 // use case: plan workouts to be performed in the future (weeks, months)
 @Composable
-fun PlanningScreenRoot(modifier: Modifier = Modifier) {
+fun PlanningScreenRoot(
+    vm: PlanningViewModel = koinViewModel(),
+    modifier: Modifier = Modifier
+) {
+    var creatingPlan by remember { mutableStateOf(false) }
+
+    Column(modifier.fillMaxSize()) {
+        if (!creatingPlan) {
+            Text("Your plans")
+            LazyColumn {
+                items(3) { idx -> Text("Plan #$idx") }
+            }
+
+            Text("Predefined plans")
+            LazyColumn {
+                items(3) { idx -> Text("Predefined plan #$idx") }
+            }
+
+            Button({ creatingPlan = true }) {
+                Text("Create a new plan")
+            }
+        } else {
+            PlanCreation(
+                vm.plan,
+                onFinished = { creatingPlan = false }
+            ) {
+                vm.onAction(it)
+            }
+        }
+    }
 }
+
+@Composable
+fun PlanCreation(
+    plan: Plan,
+    modifier: Modifier = Modifier,
+    onFinished: () -> Unit = {},
+    onAction: (PlanAction) -> Unit = {},
+) {
+    var planName by remember { mutableStateOf("") }
+    var selectedWorkoutIdx by remember { mutableStateOf<Int?>(null) }
+
+    if (selectedWorkoutIdx == null) {
+        Text("Creating a new plan")
+        Text("Plan name")
+        TextField(value = plan.name, onValueChange = { planName = it })
+
+        LazyColumn {
+            items(plan.workouts) { workout ->
+                PlanListItem(workout) {
+                    selectedWorkoutIdx = workout.idx
+                }
+            }
+        }
+
+        Button({
+            val workout = WorkoutPlan(
+                "New workout",
+                plan.workouts.size,
+                emptyList(),
+            )
+
+            onAction(PlanAction.AddWorkout(workout))
+        }) {
+            Text("Add workout day")
+        }
+        Button({ /* TODO */ }) {
+            Text("Save plan")
+        }
+        Button({ /* TODO */ }) {
+            Text("Cancel")
+        }
+    } else {
+        PlanWorkoutDetail(plan.workouts[selectedWorkoutIdx!!]) {
+            onAction(it)
+        }
+    }
+}
+
+@Composable
+fun PlanListItem(
+    workout: WorkoutPlan,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Card(onClick) {
+        Column {
+            Text(workout.name)
+            Text(workout.blocks.joinToString())
+        }
+
+    }
+}
+
+@Composable
+fun PlanWorkoutDetail(
+    workout: WorkoutPlan,
+    modifier: Modifier = Modifier,
+    onAction: (PlanAction) -> Unit = {},
+) {
+    var selectExercise by remember { mutableStateOf(false) }
+
+    Text("Selected workout: $workout")
+
+    Button({ selectExercise = true}) {
+        Text("Add exercise")
+    }
+
+    LazyColumn {
+        items(workout.blocks) {
+            BlockItem(it) {
+                // TODO add set to block
+                onAction(PlanAction.addSet)
+            }
+        }
+    }
+
+    if (selectExercise) {
+        ExerciseListScreenRoot(
+            onExerciseClick = { exercise ->
+                println("DBG: $exercise selected")
+
+                onAction(PlanAction.AddExercise(workout, exercise))
+                selectExercise = false
+            }
+        )
+    }
+}
+
+

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningScreen.kt
@@ -116,7 +116,6 @@ fun PlanListItem(
             Text(workout.name)
             Text(workout.blocks.joinToString())
         }
-
     }
 }
 
@@ -135,10 +134,12 @@ fun PlanWorkoutDetail(
     }
 
     LazyColumn {
-        items(workout.blocks) {
-            BlockItem(it) {
-                // TODO add set to block
-                onAction(PlanAction.addSet)
+        items(workout.blocks) { block ->
+            BlockItem(
+                block,
+                onAction = { onAction(PlanAction.RemoveExercise(workout, block)) }
+            ) {
+                onAction(PlanAction.AddSet(workout, block))
             }
         }
     }
@@ -154,5 +155,3 @@ fun PlanWorkoutDetail(
         )
     }
 }
-
-

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
@@ -61,6 +61,7 @@ class PlanningViewModel(
 
         viewModelScope.launch {
             planRepository.saveCustomPlan(user.id, plan)
+            plan = Plan.Empty
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
@@ -52,7 +52,6 @@ class PlanningViewModel(
             is PlanAction.RemoveSet -> removeSet(action.workout, action.block, action.set)
 
             PlanAction.ErrorHandled -> error = null
-
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
@@ -4,22 +4,32 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.github.jakubherr.gitfit.domain.AuthRepository
+import io.github.jakubherr.gitfit.domain.PlanRepository
 import io.github.jakubherr.gitfit.domain.model.Block
 import io.github.jakubherr.gitfit.domain.model.Exercise
 import io.github.jakubherr.gitfit.domain.model.Plan
+import io.github.jakubherr.gitfit.domain.model.ProgressionSettings
 import io.github.jakubherr.gitfit.domain.model.Series
 import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
+import kotlinx.coroutines.launch
 
-class PlanningViewModel: ViewModel() {
+class PlanningViewModel(
+    private val planRepository: PlanRepository,
+    private val authRepository: AuthRepository
+): ViewModel() {
     var plan by mutableStateOf(Plan("","","",""))
         private set
+
+    val userWorkouts = planRepository.getCustomWorkouts(authRepository.currentUser.id)
 
     fun onAction(action: PlanAction) {
         when (action) {
             is PlanAction.SavePlan -> TODO()
             is PlanAction.AddWorkout -> addWorkout(action.workout)
             is PlanAction.RenamePlan -> renamePlan(action.name)
-            is PlanAction.SaveWorkout -> TODO()
+            is PlanAction.SaveWorkout -> saveWorkout(action.workout)
             is PlanAction.AddExercise -> addBlock(action.workout, action.exercise)
             is PlanAction.RemoveExercise -> removeBlock(action.workout, action.block)
             is PlanAction.AddSet -> addSet(action.workout, action.block)
@@ -44,6 +54,18 @@ class PlanningViewModel: ViewModel() {
         plan = plan.copy(workouts = workouts)
     }
 
+    private fun saveWorkout(workout: WorkoutPlan) {
+        val user = authRepository.currentUser
+        if (!user.loggedIn) return
+
+        // TODO validate all fields in workout before saving
+        // for now, i will save single workouts first, TODO save collections of workouts as plans
+        println("DBG: Saving workout plan...")
+        viewModelScope.launch {
+            planRepository.saveCustomWorkout(user.id, workout)
+        }
+    }
+
     private fun addBlock(workout: WorkoutPlan, exercise: Exercise) {
         val updated = workout.copy(blocks = workout.blocks + Block("", workout.blocks.size, exercise))
         updateWorkout(updated)
@@ -53,6 +75,10 @@ class PlanningViewModel: ViewModel() {
         val newBlocks = workout.blocks.toMutableList()
         newBlocks[block.idx] = block
         updateWorkout(workout.copy(blocks = newBlocks))
+    }
+
+    private fun setProgression(workout: WorkoutPlan, block: Block, progression: ProgressionSettings) {
+        // TODO implement progression saving and evaluation
     }
 
     private fun removeBlock(workout: WorkoutPlan, block: Block) {
@@ -70,7 +96,6 @@ class PlanningViewModel: ViewModel() {
         newSeries[set.idx] = set
         updateBlock(workout, block.copy(series = newSeries))
     }
-
 }
 
 sealed interface PlanAction {

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
@@ -1,0 +1,63 @@
+package io.github.jakubherr.gitfit.presentation.planning
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import io.github.jakubherr.gitfit.domain.model.Block
+import io.github.jakubherr.gitfit.domain.model.Exercise
+import io.github.jakubherr.gitfit.domain.model.Plan
+import io.github.jakubherr.gitfit.domain.model.Series
+import io.github.jakubherr.gitfit.domain.model.WorkoutPlan
+
+class PlanningViewModel: ViewModel() {
+    var plan by mutableStateOf(Plan("","","",""))
+        private set
+
+    fun onAction(action: PlanAction) {
+        when (action) {
+            is PlanAction.SavePlan -> TODO()
+            is PlanAction.AddWorkout -> addWorkout(action.workout)
+            is PlanAction.RenamePlan -> renamePlan(action.name)
+            is PlanAction.SaveWorkout -> TODO()
+            is PlanAction.AddExercise -> addExercise(action.workout, action.exercise)
+            is PlanAction.RemoveExercise -> TODO()
+            is PlanAction.AddSet -> TODO()
+        }
+    }
+
+    private fun addWorkout(workout: WorkoutPlan) {
+        plan = plan.copy(workouts = plan.workouts + workout)
+    }
+
+    private fun saveWorkout() {
+        val workouts = plan.workouts.toMutableList()
+    }
+
+    private fun renamePlan(name: String) {
+        plan = plan.copy(name = name)
+    }
+
+    private fun addExercise(workout: WorkoutPlan, exercise: Exercise) {
+        val workouts = plan.workouts.toMutableList()
+        workouts[workout.idx] = workout.copy(blocks = workout.blocks + Block("", workout.blocks.size, exercise))
+        plan = plan.copy(workouts = workouts)
+    }
+
+    private fun addSet(workout: WorkoutPlan, block: Block) {
+        val workout = plan.workouts[workout.idx]
+        val block = workout.blocks[block.idx]
+
+        // val newBlock = block.copy(series = block.series + Series())
+    }
+}
+
+sealed interface PlanAction {
+    object SavePlan : PlanAction
+    class RenamePlan(val name: String) : PlanAction
+    class AddWorkout(val workout: WorkoutPlan) : PlanAction
+    class SaveWorkout(val workout: WorkoutPlan) : PlanAction
+    class AddExercise(val workout: WorkoutPlan, val exercise: Exercise) : PlanAction
+    class RemoveExercise(val workout: WorkoutPlan, val index: Int) : PlanAction
+    class AddSet(val workout: WorkoutPlan, val block: Block) : PlanAction
+}

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
@@ -26,11 +26,11 @@ class PlanningViewModel(
 
     fun onAction(action: PlanAction) {
         when (action) {
-            is PlanAction.SavePlan -> TODO()
+            is PlanAction.SavePlan -> savePlan()
             is PlanAction.AddWorkout -> addWorkout(action.workout)
             is PlanAction.RenamePlan -> renamePlan(action.name)
             is PlanAction.SaveWorkout -> saveWorkout(action.workout)
-            is PlanAction.AddExercise -> addBlock(action.workout, action.exercise)
+            is PlanAction.AddExercise -> addExercise(action.workoutIdx, action.exercise)
             is PlanAction.RemoveExercise -> removeBlock(action.workout, action.block)
             is PlanAction.AddSet -> addSet(action.workout, action.block)
         }
@@ -41,7 +41,14 @@ class PlanningViewModel(
     }
 
     private fun savePlan() {
+        val user = authRepository.currentUser
+        if (!user.loggedIn) return
 
+        // TODO: validate entire plan before saving
+
+        viewModelScope.launch {
+            planRepository.saveCustomPlan(user.id, plan)
+        }
     }
 
     private fun addWorkout(workout: WorkoutPlan) {
@@ -66,7 +73,8 @@ class PlanningViewModel(
         }
     }
 
-    private fun addBlock(workout: WorkoutPlan, exercise: Exercise) {
+    private fun addExercise(workoutIdx: Int, exercise: Exercise) {
+        val workout = plan.workouts[workoutIdx]
         val updated = workout.copy(blocks = workout.blocks + Block("", workout.blocks.size, exercise))
         updateWorkout(updated)
     }
@@ -103,7 +111,7 @@ sealed interface PlanAction {
     class RenamePlan(val name: String) : PlanAction
     class AddWorkout(val workout: WorkoutPlan) : PlanAction
     class SaveWorkout(val workout: WorkoutPlan) : PlanAction
-    class AddExercise(val workout: WorkoutPlan, val exercise: Exercise) : PlanAction
+    class AddExercise(val workoutIdx: Int, val exercise: Exercise) : PlanAction
     class RemoveExercise(val workout: WorkoutPlan, val block: Block) : PlanAction
     class AddSet(val workout: WorkoutPlan, val block: Block) : PlanAction
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
@@ -96,7 +96,7 @@ class PlanningViewModel(
 
     private fun addExercise(workoutIdx: Int, exercise: Exercise) {
         val workout = plan.workouts[workoutIdx]
-        val updated = workout.copy(blocks = workout.blocks + Block("", workout.blocks.size, exercise))
+        val updated = workout.copy(blocks = workout.blocks + Block(workout.blocks.size, exercise))
         updateWorkout(updated)
     }
 
@@ -116,7 +116,7 @@ class PlanningViewModel(
     }
 
     private fun addSet(workout: WorkoutPlan, block: Block) {
-        val newBlock = block.copy(series = block.series + Series("", block.series.size, null, null, false))
+        val newBlock = block.copy(series = block.series + Series(block.series.size, null, null, false))
         updateBlock(workout, newBlock)
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
@@ -20,36 +20,57 @@ class PlanningViewModel: ViewModel() {
             is PlanAction.AddWorkout -> addWorkout(action.workout)
             is PlanAction.RenamePlan -> renamePlan(action.name)
             is PlanAction.SaveWorkout -> TODO()
-            is PlanAction.AddExercise -> addExercise(action.workout, action.exercise)
-            is PlanAction.RemoveExercise -> TODO()
-            is PlanAction.AddSet -> TODO()
+            is PlanAction.AddExercise -> addBlock(action.workout, action.exercise)
+            is PlanAction.RemoveExercise -> removeBlock(action.workout, action.block)
+            is PlanAction.AddSet -> addSet(action.workout, action.block)
         }
-    }
-
-    private fun addWorkout(workout: WorkoutPlan) {
-        plan = plan.copy(workouts = plan.workouts + workout)
-    }
-
-    private fun saveWorkout() {
-        val workouts = plan.workouts.toMutableList()
     }
 
     private fun renamePlan(name: String) {
         plan = plan.copy(name = name)
     }
 
-    private fun addExercise(workout: WorkoutPlan, exercise: Exercise) {
+    private fun savePlan() {
+
+    }
+
+    private fun addWorkout(workout: WorkoutPlan) {
+        plan = plan.copy(workouts = plan.workouts + workout)
+    }
+
+    private fun updateWorkout(workout: WorkoutPlan) {
         val workouts = plan.workouts.toMutableList()
-        workouts[workout.idx] = workout.copy(blocks = workout.blocks + Block("", workout.blocks.size, exercise))
+        workouts[workout.idx] = workout
         plan = plan.copy(workouts = workouts)
     }
 
-    private fun addSet(workout: WorkoutPlan, block: Block) {
-        val workout = plan.workouts[workout.idx]
-        val block = workout.blocks[block.idx]
-
-        // val newBlock = block.copy(series = block.series + Series())
+    private fun addBlock(workout: WorkoutPlan, exercise: Exercise) {
+        val updated = workout.copy(blocks = workout.blocks + Block("", workout.blocks.size, exercise))
+        updateWorkout(updated)
     }
+
+    private fun updateBlock(workout: WorkoutPlan, block: Block) {
+        val newBlocks = workout.blocks.toMutableList()
+        newBlocks[block.idx] = block
+        updateWorkout(workout.copy(blocks = newBlocks))
+    }
+
+    private fun removeBlock(workout: WorkoutPlan, block: Block) {
+        val newWorkout = workout.copy(blocks = workout.blocks - block)
+        updateWorkout(newWorkout)
+    }
+
+    private fun addSet(workout: WorkoutPlan, block: Block) {
+        val newBlock = block.copy(series = block.series + Series("", block.series.size, null, null, false))
+        updateBlock(workout, newBlock)
+    }
+
+    private fun updateSet(workout: WorkoutPlan, block: Block, set: Series) {
+        val newSeries = plan.workouts[workout.idx].blocks[block.idx].series.toMutableList()
+        newSeries[set.idx] = set
+        updateBlock(workout, block.copy(series = newSeries))
+    }
+
 }
 
 sealed interface PlanAction {
@@ -58,6 +79,6 @@ sealed interface PlanAction {
     class AddWorkout(val workout: WorkoutPlan) : PlanAction
     class SaveWorkout(val workout: WorkoutPlan) : PlanAction
     class AddExercise(val workout: WorkoutPlan, val exercise: Exercise) : PlanAction
-    class RemoveExercise(val workout: WorkoutPlan, val index: Int) : PlanAction
+    class RemoveExercise(val workout: WorkoutPlan, val block: Block) : PlanAction
     class AddSet(val workout: WorkoutPlan, val block: Block) : PlanAction
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/settings/SettingsScreen.kt
@@ -90,7 +90,7 @@ fun SettingsScreen(
 
             authState?.value?.let { state ->
                 Spacer(Modifier.width(32.dp))
-                Text("DEBUG INFO:\n user id: ${state.user.userId} \n email verified: ${state.user.emailVerified}")
+                Text("DEBUG INFO:\n user id: ${state.user.id} \n email verified: ${state.user.emailVerified}")
 
                 // TODO some better UI
                 if (state.loading) CircularProgressIndicator()

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
@@ -87,8 +87,8 @@ fun WorkoutScreen(
                             block,
                             onAction = onAction,
                             onAddSetClicked = {
-                                val set = Series(block.series.size.toString(), 0,null, null, false) // TODO solve indexing!
-                                onAction(WorkoutAction.AddSet(workout.id, block.id, set))
+                                val set = Series(block.series.size, null, null, false)
+                                onAction(WorkoutAction.AddSet(workout.id, block.idx, set))
                             },
                         )
                     }
@@ -125,7 +125,7 @@ fun BlockItem(
                     CheckableSetInput(idx + 1, set) { weight, reps ->
                         onAction(
                             WorkoutAction.ModifySeries(
-                                blockId = block.id,
+                                blockIdx = block.idx,
                                 set =
                                     set.copy(
                                         weight = weight.toLong(),

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
@@ -122,7 +122,7 @@ fun BlockItem(
                 SetHeader()
                 Spacer(Modifier.height(16.dp))
                 block.series.forEachIndexed { idx, set ->
-                    SetItem(idx + 1, set) { weight, reps ->
+                    CheckableSetInput(idx + 1, set) { weight, reps ->
                         onAction(
                             WorkoutAction.ModifySeries(
                                 blockId = block.id,
@@ -157,7 +157,7 @@ fun SetHeader(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun SetItem(
+fun CheckableSetInput(
     index: Int,
     set: Series = mockSeries,
     modifier: Modifier = Modifier,

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
@@ -195,6 +195,7 @@ fun NumberInputField(
     label: String? = null,
     modifier: Modifier = Modifier,
     placeholder: Int = 0,
+    isError: Boolean = false,
     onValueChange: (String) -> Unit,
 ) {
     OutlinedTextField(
@@ -203,6 +204,7 @@ fun NumberInputField(
         placeholder = { Text(placeholder.toString(), modifier.alpha(0.6f)) },
         modifier = Modifier.width(64.dp),
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        isError = isError,
         singleLine = true,
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
@@ -41,6 +41,7 @@ import gitfit.composeapp.generated.resources.kg
 import gitfit.composeapp.generated.resources.reps
 import gitfit.composeapp.generated.resources.save_workout
 import gitfit.composeapp.generated.resources.set
+import io.github.jakubherr.gitfit.domain.isPositiveDouble
 import io.github.jakubherr.gitfit.domain.isPositiveLong
 import io.github.jakubherr.gitfit.domain.model.Block
 import io.github.jakubherr.gitfit.domain.model.Series
@@ -128,7 +129,7 @@ fun BlockItem(
                                 blockIdx = block.idx,
                                 set =
                                     set.copy(
-                                        weight = weight.toLong(),
+                                        weight = weight.toDouble(),
                                         repetitions = reps.toLong(),
                                         completed = !set.completed,
                                     ),
@@ -173,13 +174,22 @@ fun CheckableSetInput(
     ) {
         Text(index.toString())
 
-        NumberInputField(weight, onValueChange = { weight = it })
+        NumberInputField(
+            weight,
+            onValueChange = { newWeight ->
+                // limits the number of decimal points to 2
+                val decimals = newWeight.substringAfter(".", "")
+                if (decimals.length < 3) {
+                    weight = newWeight
+                }
+            }
+        )
         NumberInputField(reps, onValueChange = { reps = it })
 
         Checkbox(
             set.completed,
             onCheckedChange = {
-                if (weight.isPositiveLong() && reps.isPositiveLong()) {
+                if (weight.isPositiveDouble() && reps.isPositiveLong()) {
                     onToggle(weight, reps)
                 } else {
                     println("DBG: either weight: $weight or reps $reps is not a valid Long") // TODO show error in ui

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutScreen.kt
@@ -87,7 +87,7 @@ fun WorkoutScreen(
                             block,
                             onAction = onAction,
                             onAddSetClicked = {
-                                val set = Series(block.series.size.toString(), null, null, false)
+                                val set = Series(block.series.size.toString(), 0,null, null, false) // TODO solve indexing!
                                 onAction(WorkoutAction.AddSet(workout.id, block.id, set))
                             },
                         )

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutViewModel.kt
@@ -33,8 +33,8 @@ class WorkoutViewModel(
             is WorkoutAction.DeleteWorkout -> deleteWorkout(action.workoutId)
             is WorkoutAction.AskForExercise -> { }
             is WorkoutAction.AddBlock -> addBlock(action.workoutId, action.exerciseId)
-            is WorkoutAction.AddSet -> addSet(action.workoutId, action.blockId, action.set)
-            is WorkoutAction.ModifySeries -> modifySeries(action.blockId, action.set)
+            is WorkoutAction.AddSet -> addSet(action.workoutId, action.blockIdx, action.set)
+            is WorkoutAction.ModifySeries -> modifySeries(action.blockIdx, action.set)
         }
     }
 
@@ -71,18 +71,18 @@ class WorkoutViewModel(
 
     private fun addSet(
         workoutId: String,
-        blockId: String,
+        blockIdx: Int,
         set: Series,
     ) {
-        viewModelScope.launch { workoutRepository.addSeries(workoutId, blockId, set) }
+        viewModelScope.launch { workoutRepository.addSeries(workoutId, blockIdx, set) }
     }
 
     private fun modifySeries(
-        blockId: String,
+        blockIdx: Int,
         set: Series,
     ) {
         val workoutId = currentWorkout.value?.id ?: return // TODO error handling
-        viewModelScope.launch { workoutRepository.modifySeries(workoutId, blockId, set) }
+        viewModelScope.launch { workoutRepository.modifySeries(workoutId, blockIdx, set) }
     }
 }
 
@@ -93,9 +93,9 @@ sealed interface WorkoutAction {
 
     class AddBlock(val workoutId: String, val exerciseId: String) : WorkoutAction
 
-    class AddSet(val workoutId: String, val blockId: String, val set: Series) : WorkoutAction
+    class AddSet(val workoutId: String, val blockIdx: Int, val set: Series) : WorkoutAction
 
-    class ModifySeries(val blockId: String, val set: Series) : WorkoutAction
+    class ModifySeries(val blockIdx: Int, val set: Series) : WorkoutAction
 
     class CompleteWorkout(val workoutId: String) : WorkoutAction
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/workout/WorkoutViewModel.kt
@@ -28,7 +28,7 @@ class WorkoutViewModel(
     fun onAction(action: WorkoutAction) {
         when (action) {
             is WorkoutAction.StartNewWorkout -> startNewWorkout()
-            is WorkoutAction.StartPlannedWorkout -> startPlannedWorkout(action.workoutId)
+            is WorkoutAction.StartPlannedWorkout -> startPlannedWorkout(action.planId, action.workoutIdx)
             is WorkoutAction.CompleteWorkout -> completeWorkout(action.workoutId)
             is WorkoutAction.DeleteWorkout -> deleteWorkout(action.workoutId)
             is WorkoutAction.AskForExercise -> { }
@@ -46,10 +46,10 @@ class WorkoutViewModel(
         }
     }
 
-    private fun startPlannedWorkout(workoutId: String) {
+    private fun startPlannedWorkout(planId: String, workoutIdx: Int) {
         if (currentWorkout.value == null) {
             viewModelScope.launch {
-                workoutRepository.startPlannedWorkout(workoutId)
+                workoutRepository.startWorkoutFromPlan(planId, workoutIdx)
             }
         }
     }
@@ -89,7 +89,7 @@ class WorkoutViewModel(
 sealed interface WorkoutAction {
     object StartNewWorkout : WorkoutAction
 
-    class StartPlannedWorkout(val workoutId: String) : WorkoutAction
+    class StartPlannedWorkout(val planId: String, val workoutIdx: Int) : WorkoutAction
 
     class AddBlock(val workoutId: String, val exerciseId: String) : WorkoutAction
 


### PR DESCRIPTION
Implements part of #4

User now has the ability to:
- create a new training plan
- Add workout days that represent the plan
- add and remove exercise from workout
- add sets with repetition and weights to exercise
- save plan to online database
- edit an existing plan
- start a new workout from a plan

Application does the following client side validations of plan before saving:
- plan has a name and contains at least one workout
- every workout contains at least one exercise
- every exercise contains at least one set
- every set contains a valid value for weight and repetitions
- repetition must be a non-negative integer
- weight must be a non-negative double with up to 2 decimal points