### PR TITLE
Feature/add basic unit tests

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -23,18 +23,6 @@ kotlin {
 
     jvm("desktop")
 
-    // this is necessary to force GitLive to use commonMain instead of JVM dependency in the common module
-//    listOf(
-//        iosX64(),
-//        iosArm64(),
-//        iosSimulatorArm64(),
-//    ).forEach { iosTarget ->
-//        iosTarget.binaries.framework {
-//            baseName = "ComposeApp"
-//            isStatic = true
-//        }
-//    }
-
     sourceSets {
         val desktopMain by getting
 
@@ -77,6 +65,10 @@ kotlin {
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.swing)
+        }
+
+        commonTest.dependencies { 
+            implementation(libs.kotlin.test)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Block.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Block.kt
@@ -27,21 +27,23 @@ data class Block(
         return copy(series = newSeries)
     }
 
-    fun progressWeight(increment: Double): Block {
+    fun progressWeight(): Block {
+        progressionSettings?.incrementWeightByKg ?: return this
         val newSeries = series.toMutableList()
         newSeries.forEachIndexed { idx, series ->
-            newSeries[idx] = series.copy(weight = (series.weight ?: 0.0) + increment, completed = false)
+            newSeries[idx] = series.copy(weight = (series.weight ?: 0.0) + progressionSettings.incrementWeightByKg, completed = false)
         }
-        val newProgression = progressionSettings?.copy(weightThreshold = progressionSettings.weightThreshold + increment)
+        val newProgression = progressionSettings.copy(weightThreshold = progressionSettings.weightThreshold + progressionSettings.incrementWeightByKg)
         return copy(series = newSeries, progressionSettings = newProgression)
     }
 
-    fun progressReps(increment: Int): Block {
+    fun progressReps(): Block {
+        progressionSettings?.incrementRepsBy ?: return this
         val newSeries = series.toMutableList()
         newSeries.forEachIndexed { idx, series ->
-            newSeries[idx] = series.copy(repetitions = (series.repetitions ?: 0) + increment, completed = false)
+            newSeries[idx] = series.copy(repetitions = (series.repetitions ?: 0) + progressionSettings.incrementRepsBy, completed = false)
         }
-        val newProgression = progressionSettings?.copy(repThreshold = progressionSettings.repThreshold + increment)
+        val newProgression = progressionSettings.copy(repThreshold = progressionSettings.repThreshold + progressionSettings.incrementRepsBy)
         return copy(series = newSeries, progressionSettings = newProgression)
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Exercise.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Exercise.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 data class Exercise(
     val id: String,
     val name: String,
-    val description: String?,
+    val description: String? = null,
     val isCustom: Boolean = false,
     val primaryMuscle: MuscleGroup,
     val secondaryMuscle: List<MuscleGroup> = emptyList(),

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Plan.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/Plan.kt
@@ -33,7 +33,14 @@ data class Plan(
         return copy(workoutPlans = workouts)
     }
 
-    fun removeWorkoutPlan(workoutPlan: WorkoutPlan): Plan = copy(workoutPlans = workoutPlans - workoutPlan)
+    fun removeWorkoutPlan(workoutPlan: WorkoutPlan): Plan {
+        val workouts = workoutPlans.toMutableList()
+        workouts.remove(workoutPlan)
+        workouts.forEachIndexed { index, oldWorkoutPlan ->
+            workouts[index] = oldWorkoutPlan.copy(idx = index)
+        }
+        return copy(workoutPlans = workouts)
+    }
 
     fun addExercise(workoutPlanIdx: Int, exercise: Exercise): Plan {
         val workout = workoutPlans[workoutPlanIdx]

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/WorkoutPlan.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/WorkoutPlan.kt
@@ -34,6 +34,46 @@ data class WorkoutPlan(
         return copy(blocks = newBlocks)
     }
 
+    // check workout record for valid progression and update plan accordingly
+    //  Some restrictions were made on editing workout records with progression to prevent user from shooting themselves in the foot
+    //  progression can NOT be changed mid-workout
+    //  user can NOT remove block with progression
+    //  user CAN add a new block without a progression -> OK
+    //  user can NOT change order of exercises
+    fun progressPlan(workoutRecord: Workout): WorkoutPlan {
+        // filter out all blocks in workout record that have progression. if none are found, exit
+        val blocksWithProgression = workoutRecord.blocks.filter { it.progressionSettings != null }.ifEmpty { return this }
+        var workoutPlanCopy = this
+
+        // check both record and plan have the same amount of progression blocks at the same indexes
+        // if this check fails, the record is too different from the plan and progression will not happen
+        val planProgressionBlocks = workoutPlanCopy.blocks.filter { it.progressionSettings != null }
+        if (blocksWithProgression.map { it.idx } != planProgressionBlocks.map {it.idx}) return this
+
+        // check every recorded block with progression for progress threshold criteria
+        blocksWithProgression.forEach { recordedBlock ->
+            val settings = recordedBlock.progressionSettings!!
+            val shouldProgress = recordedBlock.series.all { series ->
+                series.completed && series.isNotNull && series.weight!! >= settings.weightThreshold && series.repetitions!! >= settings.repThreshold
+            }
+
+            // if criteria was met
+            if (shouldProgress) {
+                val planBlock = workoutPlanCopy.blocks[recordedBlock.idx]
+
+                // increment all block weight/reps by increment
+                // increment value in progression setting
+                // save block to workout plan and then save it to plan
+                when (settings.type) {
+                    ProgressionType.INCREASE_WEIGHT -> workoutPlanCopy = workoutPlanCopy.updateBlock(planBlock.progressWeight())
+                    ProgressionType.INCREASE_REPS -> workoutPlanCopy = workoutPlanCopy.updateBlock(planBlock.progressReps())
+                }
+            }
+        }
+
+        return workoutPlanCopy
+    }
+
     companion object {
         fun Empty(idx: Int) = WorkoutPlan(
             "New workout",

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/WorkoutPlan.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/domain/model/WorkoutPlan.kt
@@ -13,7 +13,7 @@ data class WorkoutPlan(
         name.isBlank() -> Error.BlankName
         blocks.isEmpty() -> Error.NoExerciseInWorkout
         blocks.any { block -> block.series.isEmpty() } -> Error.NoSetInExercise
-        blocks.any { block -> block.series.any { series -> series.weight == null || series.repetitions == null } } -> Error.EmptySetInExercise
+        blocks.any { block -> block.series.any { series -> series.weight == null || series.repetitions == null } } -> Error.InvalidSetInExercise
         else -> null
     }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jakubherr/gitfit/presentation/planning/PlanningViewModel.kt
@@ -94,7 +94,7 @@ sealed interface PlanAction {
     class DeletePlan(val planId: String) : PlanAction
 
     class AddWorkout(val workout: WorkoutPlan) : PlanAction
-    class RenameWorkout(val workout: WorkoutPlan, val name: String) : PlanAction // TODO will this break validation?
+    class RenameWorkout(val workout: WorkoutPlan, val name: String) : PlanAction
     class ValidateWorkout(val workout: WorkoutPlan) : PlanAction
     class DeleteWorkout(val workout: WorkoutPlan) : PlanAction
 

--- a/composeApp/src/commonTest/kotlin/io/github/jakubherr/gitfit/domain/model/BlockTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jakubherr/gitfit/domain/model/BlockTest.kt
@@ -1,0 +1,173 @@
+package io.github.jakubherr.gitfit.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BlockTest {
+    private val testExercise = Exercise("exerciseId", "exerciseName", primaryMuscle = MuscleGroup.CHEST)
+
+    @Test
+    fun weightProgressesWhenItShould() {
+        // given a completed block with valid weight progression settings that meet progression criteria
+        val originalBlock = Block(
+            idx = 0,
+            exercise = testExercise,
+            series = listOf(
+                Series(
+                    idx = 0,
+                    repetitions = 10,
+                    weight = 25.0,
+                    completed = true
+                ),
+                Series(
+                    idx = 0,
+                    repetitions = 10,
+                    weight = 20.0,
+                    completed = true
+                )
+            ),
+            progressionSettings = ProgressionSettings(
+                incrementWeightByKg = 5.12,
+                type = ProgressionType.INCREASE_WEIGHT,
+                trigger = ProgressionTrigger.MINIMUM_REPS_AND_WEIGHT_EVERY_SET,
+                incrementRepsBy = 0,
+                weightThreshold = 20.0,
+                repThreshold = 10,
+            )
+        )
+
+        // when block is progressed
+        val updatedBlock = originalBlock.progressWeight()
+
+        // then all weights in block are increased by 5.12 kg and repetitions stay the same
+        assertTrue {
+            updatedBlock.series[0].weight == 30.12 &&
+            updatedBlock.series[0].repetitions == 10L &&
+            updatedBlock.series[1].weight == 25.12 &&
+            updatedBlock.series[1].repetitions == 10L
+        }
+        // and progression setting weight threshold is updated for the next progression
+        assertTrue {
+            updatedBlock.progressionSettings?.weightThreshold == 25.12
+        }
+    }
+
+    @Test
+    fun repetitionProgressesWhenItShould() {
+        // given a completed block with valid repetition progression settings that meet progression criteria
+        val originalBlock = Block(
+            idx = 0,
+            exercise = testExercise,
+            series = listOf(
+                Series(
+                    idx = 0,
+                    repetitions = 10,
+                    weight = 25.0,
+                    completed = true
+                ),
+                Series(
+                    idx = 0,
+                    repetitions = 10,
+                    weight = 20.0,
+                    completed = true
+                )
+            ),
+            progressionSettings = ProgressionSettings(
+                incrementWeightByKg = 0.0,
+                type = ProgressionType.INCREASE_REPS,
+                trigger = ProgressionTrigger.MINIMUM_REPS_AND_WEIGHT_EVERY_SET,
+                incrementRepsBy = 2,
+                weightThreshold = 20.0,
+                repThreshold = 10,
+            )
+        )
+
+        // when block is updated
+        val updatedBlock = originalBlock.progressReps()
+
+        // then all repetitions in the block are updated and weight stays the same
+        assertTrue {
+            updatedBlock.series[0].repetitions == 12L &&
+            updatedBlock.series[0].weight == 25.00 &&
+            updatedBlock.series[1].repetitions == 12L &&
+            updatedBlock.series[1].weight == 20.0
+        }
+        // and progression setting repetition threshold is updated for the next progression
+        assertTrue { updatedBlock.progressionSettings?.repThreshold == 12 }
+    }
+
+    @Test
+    fun weightStaysTheSameWhenItShould() {
+        // given a block where user did not meet progression criteria
+        val originalBlock = Block(
+            idx = 0,
+            exercise = testExercise,
+            series = listOf(
+                Series(
+                    idx = 0,
+                    repetitions = 10,
+                    weight = 25.0,
+                    completed = true
+                ),
+                Series(
+                    idx = 0,
+                    repetitions = 10,
+                    weight = 20.0,
+                    completed = true
+                )
+            ),
+            progressionSettings = ProgressionSettings(
+                incrementWeightByKg = 5.00,
+                type = ProgressionType.INCREASE_WEIGHT,
+                trigger = ProgressionTrigger.MINIMUM_REPS_AND_WEIGHT_EVERY_SET,
+                incrementRepsBy = 0,
+                weightThreshold = 44.0,
+                repThreshold = 10,
+            )
+        )
+
+        // when weight is progressed
+        val updatedBlock = originalBlock.progressWeight()
+
+        // then the block stays the same
+        assertEquals(updatedBlock, originalBlock)
+    }
+
+    @Test
+    fun repetitionsStayTheSameWhenTheyShould() {
+        // given a block where user did not meet progression criteria
+        val originalBlock = Block(
+            idx = 0,
+            exercise = testExercise,
+            series = listOf(
+                Series(
+                    idx = 0,
+                    repetitions = 10,
+                    weight = 25.0,
+                    completed = true
+                ),
+                Series(
+                    idx = 0,
+                    repetitions = 10,
+                    weight = 20.0,
+                    completed = true
+                )
+            ),
+            progressionSettings = ProgressionSettings(
+                incrementWeightByKg = 0.0,
+                type = ProgressionType.INCREASE_REPS,
+                trigger = ProgressionTrigger.MINIMUM_REPS_AND_WEIGHT_EVERY_SET,
+                incrementRepsBy = 2,
+                weightThreshold = 20.0,
+                repThreshold = 15,
+            )
+        )
+
+        // when repetitions are progressed
+        val updatedBlock = originalBlock.progressReps()
+
+        // then the block stays the same
+        assertEquals(originalBlock, updatedBlock)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/jakubherr/gitfit/domain/model/PlanTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jakubherr/gitfit/domain/model/PlanTest.kt
@@ -1,0 +1,185 @@
+package io.github.jakubherr.gitfit.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PlanTest {
+    private val testExercise = Exercise("exerciseId", "exerciseName", primaryMuscle = MuscleGroup.CHEST)
+
+    @Test
+    fun errorCheckingWorks() {
+        // given plan with blank name
+        var plan = Plan(
+            id = "testPlan",
+            userId = "testUser",
+            name = "",
+            description = "",
+        )
+        assertEquals(Plan.Error.InvalidPlanName, plan.error)
+
+        // given named plan with no workout days
+        plan = plan.copy(name = "Named plan")
+        assertEquals(Plan.Error.NoWorkoutInPlan, plan.error)
+
+        // given plan with workout with no exercises
+        plan = plan.addWorkoutPlan(WorkoutPlan.Empty(plan.workoutPlans.size))
+        assertTrue {
+            val error = plan.error
+            error is Plan.Error.InvalidWorkout && error.error is Workout.Error.NoExerciseInWorkout
+        }
+
+        // given plan with workout with exercise with no series
+        plan = plan.addExercise(0, testExercise)
+        assertTrue {
+            val error = plan.error
+            error is Plan.Error.InvalidWorkout && error.error is Workout.Error.NoSetInExercise
+        }
+
+        // given plan with workout with exercise with empty series
+        val workoutPlan1 = plan.workoutPlans[0]
+        plan = plan.addSeries(workoutPlan1, workoutPlan1.blocks[0])
+        assertTrue {
+            val error = plan.error
+            error is Plan.Error.InvalidWorkout && error.error is Workout.Error.InvalidSetInExercise
+        }
+
+        // given plan with valid workout with blank name
+        val workoutPlan2 = plan.workoutPlans[0]
+        plan = plan.updateSeries(workoutPlan2, workoutPlan2.blocks[0], Series(0, 5, 10.0, true))
+        plan = plan.updateWorkoutPlan(plan.workoutPlans.first().copy(name = ""))
+        assertTrue {
+            val error = plan.error
+            error is Plan.Error.InvalidWorkout && error.error is Workout.Error.BlankName
+        }
+
+        // given plan with valid workout and valid name
+        val workoutPlan3 = plan.workoutPlans[0]
+        plan = plan.updateWorkoutPlan(workoutPlan3.copy(name = "named workout"))
+        assertNull(plan.error)
+    }
+
+    @Test
+    fun workoutPlanCRUD() {
+        // given empty plan
+        var plan = Plan(
+            id = "testPlan",
+            userId = "testUser",
+            name = "plan name",
+            description = "",
+            workoutPlans = emptyList(),
+        )
+
+        // workout plans can be added
+        plan = plan
+            .addWorkoutPlan(WorkoutPlan.Empty(0))
+            .addWorkoutPlan(WorkoutPlan.Empty(1))
+            .addWorkoutPlan(WorkoutPlan.Empty(2))
+        assertEquals(3, plan.workoutPlans.size)
+
+        // workout plans can be updated
+        plan = plan.updateWorkoutPlan(plan.workoutPlans.first().copy("updated workout name"))
+        assertEquals("updated workout name", plan.workoutPlans.first().name)
+
+        // workout plans can be deleted, even out of order
+        plan = plan.removeWorkoutPlan(plan.workoutPlans[1])
+        assertEquals(2, plan.workoutPlans.size)
+        assertTrue {
+            plan.workoutPlans.forEachIndexed { index, workoutPlan ->
+                if (workoutPlan.idx != index) return@assertTrue false
+            }
+            true
+        }
+    }
+
+    // this test also indirectly validates WorkoutPlan
+    @Test
+    fun exerciseCRUD() {
+        // given plan with empty workout day
+        var plan = Plan(
+            id = "testPlan",
+            userId = "testUser",
+            name = "plan name",
+            description = "",
+            workoutPlans = listOf(
+                WorkoutPlan(
+                    name = "workout plan",
+                    idx = 0,
+                    blocks =  emptyList()
+                )
+            ),
+        )
+
+        // exercise blocks can be added
+        plan = plan
+            .addExercise(0, testExercise)
+            .addExercise(0, testExercise)
+            .addExercise(0, testExercise)
+        assertEquals(3, plan.workoutPlans[0].blocks.size)
+
+        // exercise blocks can be removed, even out of order
+        plan = plan.removeBlock(plan.workoutPlans[0], plan.workoutPlans[0].blocks[1])
+        assertEquals(2, plan.workoutPlans[0].blocks.size)
+        assertTrue {
+            plan.workoutPlans[0].blocks.forEachIndexed { index, block ->
+                if (block.idx != index) return@assertTrue false
+            }
+            true
+        }
+    }
+
+    // this test also indirectly validates WorkoutPlan, Block and Series
+    @Test
+    fun seriesCRUD() {
+        // given plan with workout day with empty exercise
+        var plan = Plan(
+            id = "testPlan",
+            userId = "testUser",
+            name = "plan name",
+            description = "",
+            workoutPlans = listOf(
+                WorkoutPlan(
+                    name = "workout plan",
+                    idx = 0,
+                    blocks =  listOf(
+                        Block(
+                            idx = 0,
+                            testExercise,
+                            series = emptyList()
+                        )
+                    )
+                )
+            ),
+        )
+
+        // series can be added
+        plan = plan.addSeries(plan.workoutPlans[0], plan.workoutPlans[0].blocks[0])
+        plan = plan.addSeries(plan.workoutPlans[0], plan.workoutPlans[0].blocks[0])
+        plan = plan.addSeries(plan.workoutPlans[0], plan.workoutPlans[0].blocks[0])
+        assertEquals(3, plan.workoutPlans[0].blocks[0].series.size)
+
+        // series can be updated
+        val newSeries = plan.workoutPlans[0].blocks[0].series[0].copy(weight = 80.0, repetitions = 12)
+        plan = plan.updateSeries(
+            plan.workoutPlans[0],
+            plan.workoutPlans[0].blocks[0],
+            newSeries
+        )
+        assertEquals(newSeries, plan.workoutPlans[0].blocks[0].series[0])
+
+        // series can be removed, even out of order
+        plan = plan.removeSeries(
+            plan.workoutPlans[0],
+            plan.workoutPlans[0].blocks[0],
+            plan.workoutPlans[0].blocks[0].series[1]
+        )
+        assertEquals(2, plan.workoutPlans[0].blocks[0].series.size)
+        assertTrue {
+            plan.workoutPlans[0].blocks[0].series.forEachIndexed { index, series ->
+                if (series.idx != index) return@assertTrue false
+            }
+            true
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/jakubherr/gitfit/domain/model/WorkoutPlanTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jakubherr/gitfit/domain/model/WorkoutPlanTest.kt
@@ -1,0 +1,178 @@
+package io.github.jakubherr.gitfit.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WorkoutPlanTest {
+    private val testExercise = Exercise("exerciseId", "exerciseName", primaryMuscle = MuscleGroup.CHEST)
+
+    private val originalPlan = WorkoutPlan(
+        idx = 0,
+        name = "original",
+        blocks = listOf(
+            Block(
+                idx = 0,
+                exercise = testExercise,
+                series = listOf(
+                    Series(
+                        idx = 0,
+                        repetitions = 10,
+                        weight = 50.0,
+                        completed = false
+                    )
+                ),
+                progressionSettings = null
+            ),
+            Block(
+                idx = 1,
+                exercise = testExercise,
+                series = listOf(
+                    Series(
+                        idx = 0,
+                        repetitions = 5,
+                        weight = 20.0,
+                        completed = false
+                    ),
+                    Series(
+                        idx = 1,
+                        repetitions = 5,
+                        weight = 20.0,
+                        completed = false
+                    )
+                ),
+                progressionSettings = ProgressionSettings(
+                    type = ProgressionType.INCREASE_WEIGHT,
+                    trigger = ProgressionTrigger.MINIMUM_REPS_AND_WEIGHT_EVERY_SET,
+                    incrementWeightByKg = 2.5,
+                    incrementRepsBy = 0,
+                    weightThreshold = 20.0,
+                    repThreshold = 5,
+                )
+            )
+        )
+    )
+
+    @Test
+    fun validProgression() {
+        // given a recorded workout with progression
+        val workoutRecord = Workout(
+            id = "workoutId",
+            completed = true,
+            inProgress = false,
+            blocks = listOf(
+                Block(
+                    idx = 0,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 10,
+                            weight = 60.0,
+                            completed = true
+                        )
+                    ),
+                    progressionSettings = null
+                ),
+                Block(
+                    idx = 1,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 5,
+                            weight = 20.0,
+                            completed = true
+                        ),
+                        Series(
+                            idx = 1,
+                            repetitions = 5,
+                            weight = 20.0,
+                            completed = true
+                        )
+                    ),
+                    progressionSettings = ProgressionSettings(
+                        type = ProgressionType.INCREASE_WEIGHT,
+                        trigger = ProgressionTrigger.MINIMUM_REPS_AND_WEIGHT_EVERY_SET,
+                        incrementWeightByKg = 2.5,
+                        incrementRepsBy = 0,
+                        weightThreshold = 20.0,
+                        repThreshold = 5,
+                    )
+                )
+            )
+        )
+
+        // when user progresses a plan from a workout record
+        val updatedPlan = originalPlan.progressPlan(workoutRecord)
+
+        // then blocks with completed progression criteria get progressed
+        assertEquals(22.5, updatedPlan.blocks[1].progressionSettings?.weightThreshold)
+        assertEquals(5, updatedPlan.blocks[1].progressionSettings?.repThreshold)
+        assertTrue {
+            updatedPlan.blocks[1].series.all { it.weight == 22.5 && it.repetitions == 5L }
+        }
+
+        // and blocks without progression stay the same
+        assertTrue {
+            updatedPlan.blocks[0].series.all { it.weight == 50.0 && it.repetitions == 10L }
+        }
+    }
+
+    @Test
+    fun invalidProgression() {
+        // given workout record based on workout plan, where user changed ordering of blocks with progression
+        val workoutRecord = Workout(
+            id = "workoutId",
+            completed = true,
+            inProgress = false,
+            blocks = listOf(
+                Block(
+                    idx = 0,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 5,
+                            weight = 20.0,
+                            completed = true
+                        ),
+                        Series(
+                            idx = 1,
+                            repetitions = 5,
+                            weight = 20.0,
+                            completed = true
+                        )
+                    ),
+                    progressionSettings = ProgressionSettings(
+                        type = ProgressionType.INCREASE_WEIGHT,
+                        trigger = ProgressionTrigger.MINIMUM_REPS_AND_WEIGHT_EVERY_SET,
+                        incrementWeightByKg = 2.5,
+                        incrementRepsBy = 0,
+                        weightThreshold = 20.0,
+                        repThreshold = 5,
+                    )
+                ),
+                Block(
+                    idx = 1,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 10,
+                            weight = 60.0,
+                            completed = true
+                        )
+                    ),
+                    progressionSettings = null
+                )
+            )
+        )
+
+        // when the plan is progressed
+        val progressedPlan = originalPlan.progressPlan(workoutRecord)
+
+        // then nothing happens, because the record differs from the plan too much
+        assertEquals(originalPlan, progressedPlan)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/jakubherr/gitfit/domain/model/WorkoutTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jakubherr/gitfit/domain/model/WorkoutTest.kt
@@ -1,0 +1,259 @@
+package io.github.jakubherr.gitfit.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WorkoutTest {
+    private val testExercise = Exercise("exerciseId", "exerciseName", primaryMuscle = MuscleGroup.CHEST)
+
+    @Test
+    fun whenWorkoutDoesNotContainExerciseReturnNull() {
+        // given a workout with a valid exercise with completed sets
+        val workout = Workout(
+            id = "id",
+            blocks = listOf(
+                Block(
+                    idx = 0,
+                    testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 10,
+                            weight = 70.0,
+                            completed = true
+                        )
+                    )
+                )
+            )
+        )
+
+        // metrics for another exercise that is not in the workout should be null
+        assertNull(workout.getExerciseTotalWorkoutVolume("differentExerciseId"))
+    }
+
+    @Test
+    fun ignoreUncompletedSeriesInCalculations() {
+        // given a workout with an exercise with one completed and one uncompleted series
+        val workout = Workout(
+            id = "id",
+            blocks = listOf(
+                Block(
+                    idx = 0,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 12,
+                            weight = 20.0,
+                            completed = true
+                        ),
+                        Series(
+                            idx = 1,
+                            repetitions = 21,
+                            weight = 35.0,
+                            completed = false
+                        )
+                    )
+                )
+            )
+        )
+
+        // uncompleted series should not impact metric calculations
+        assertEquals(20.0, workout.getExerciseHeaviestWeight(testExercise.id))
+        assertEquals(240.0, workout.getExerciseBestSetVolume(testExercise.id))
+        assertEquals(240.0, workout.getExerciseTotalWorkoutVolume(testExercise.id))
+        assertEquals(12, workout.getExerciseTotalRepetitions(testExercise.id))
+    }
+
+    @Test
+    fun ignoreSeriesWithMissingValues() {
+        // given a workout with an exercise that has one valid series and one with missing values
+        val workout = Workout(
+            id = "id",
+            blocks = listOf(
+                Block(
+                    idx = 0,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = null,
+                            weight = 35.0,
+                            completed = true
+                        ),
+                        Series(
+                            idx = 1,
+                            repetitions = 21,
+                            weight = 20.0,
+                            completed = true
+                        )
+                    )
+                )
+            )
+        )
+
+        // broken and invalid series should not impact calculations
+        assertEquals(20.0, workout.getExerciseHeaviestWeight(testExercise.id))
+        assertEquals(420.0, workout.getExerciseBestSetVolume(testExercise.id))
+        assertEquals(420.0, workout.getExerciseTotalWorkoutVolume(testExercise.id))
+        assertEquals(21, workout.getExerciseTotalRepetitions(testExercise.id))
+    }
+
+    @Test
+    fun calculationsWorkAcrossBlocks() {
+        // given workout with two blocks with the same exercise, with valid completed series in both blocks
+        val workout = Workout(
+            id = "id",
+            blocks = listOf(
+                Block(
+                    idx = 0,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 10,
+                            weight = 35.0,
+                            completed = true
+                        ),
+                        Series(
+                            idx = 1,
+                            repetitions = 20,
+                            weight = 20.0,
+                            completed = true
+                        )
+                    )
+                ),
+                Block(
+                    idx = 1,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 22,
+                            weight = 35.0,
+                            completed = true
+                        ),
+                        Series(
+                            idx = 1,
+                            repetitions = 3,
+                            weight = 40.0,
+                            completed = true
+                        )
+                    )
+                )
+            )
+        )
+
+        // metric calculations aggregate data from both blocks
+        assertEquals(40.0, workout.getExerciseHeaviestWeight(testExercise.id))
+        assertEquals(770.0, workout.getExerciseBestSetVolume(testExercise.id))
+        assertEquals(1640.0, workout.getExerciseTotalWorkoutVolume(testExercise.id))
+        assertEquals(55, workout.getExerciseTotalRepetitions(testExercise.id))
+    }
+
+    @Test
+    fun heaviestWeightCalculationIgnoresSeriesWith0Repetitions() {
+        // given a workout with an exercise with a series with heavier weight but no repetitions
+        val workout = Workout(
+            id = "id",
+            blocks = listOf(
+                Block(
+                    idx = 0,
+                    exercise = testExercise,
+                    series = listOf(
+                        Series(
+                            idx = 0,
+                            repetitions = 0,
+                            weight = 100.0,
+                            completed = true
+                        ),
+                        Series(
+                            idx = 1,
+                            repetitions = 12,
+                            weight = 70.0,
+                            completed = true
+                        )
+                    )
+                )
+            )
+        )
+
+        // the heavier series is ignored and lighter series is selected
+        assertEquals(70.0, workout.getExerciseHeaviestWeight(testExercise.id))
+    }
+
+    @Test
+    fun outOfOrderExerciseDeletionWorks() {
+        // given workout with three exercise blocks
+        var workout = Workout(
+            id = "id",
+            blocks = listOf(
+                Block(
+                    idx = 0,
+                    exercise = testExercise
+                ),
+                Block(
+                    idx = 1,
+                    exercise = Exercise("middleId", "middle exercise", primaryMuscle = MuscleGroup.LEGS)
+                ),
+                Block(
+                    idx = 2,
+                    exercise = Exercise("lastId", "last exercise", primaryMuscle = MuscleGroup.SHOULDERS)
+                )
+            )
+        )
+
+        // when exercise is deleted from the middle
+        workout = workout.removeBlock(1)
+
+        // exercise block is removed and block indexes are updated
+        assertFalse(workout.hasExercise("middleId"))
+        assertTrue {
+            workout.blocks.forEachIndexed { index, block ->
+                if (block.idx != index) return@assertTrue false
+            }
+            true
+        }
+    }
+
+    @Test
+    fun errorCheckingWorks() {
+        // given workout without exercise blocks
+        var workout = Workout(
+            id = "id",
+            blocks = emptyList(),
+        )
+        assertEquals(Workout.Error.NoExerciseInWorkout, workout.error)
+
+        // given workout with exercise block without series
+        workout = workout.addBlock(Exercise("exerciseId", "exerciseName", primaryMuscle = MuscleGroup.CHEST))
+        assertEquals(Workout.Error.NoSetInExercise, workout.error)
+
+        // given workout with exercise block with empty series
+        workout = workout.updateBlock(workout.blocks.first().addSeries())
+        assertEquals(Workout.Error.InvalidSetInExercise, workout.error)
+
+        // given workout with exercise block with series that is missing values
+        workout = workout.updateBlock(
+            workout.blocks.first().updateSeries(
+                workout.blocks.first().series.first().copy(
+                    weight = 20.5
+                )
+            )
+        )
+        assertEquals(Workout.Error.InvalidSetInExercise, workout.error)
+
+        // given workout with one exercise with one series with valid series
+        workout = workout.updateBlock(
+            workout.blocks.first().updateSeries(
+                workout.blocks.first().series.first().copy(
+                    weight = 20.5, repetitions = 5
+                )
+            )
+        )
+        assertNull(workout.error)
+    }
+}


### PR DESCRIPTION
this pull request solves #16 

Currently, the unit tests are fully multiplatform and test the most important domain logic
- Plan CRUD operations and validation
- exercise Block progression
- WorkoutPlan progression based on recorded Workout
- Workout exercise metric calculations and validation
- all CRUD operations with data classes that are a part of workout records and plans - Block, Series  